### PR TITLE
feat: #2 Azure infrastructure IaC

### DIFF
--- a/.github/workflows/azure-swa.yml
+++ b/.github/workflows/azure-swa.yml
@@ -1,0 +1,82 @@
+name: Azure Static Web Apps CI/CD
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches:
+      - main
+
+env:
+  NODE_VERSION: '22'
+
+jobs:
+  build_and_test:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    runs-on: ubuntu-latest
+    name: Build and Test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-build
+          path: dist/
+
+  deploy:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    needs: build_and_test
+    runs-on: ubuntu-latest
+    name: Deploy to SWA
+    environment:
+      name: ${{ github.event_name == 'pull_request' && format('preview-pr-{0}', github.event.pull_request.number) || 'production' }}
+      url: ${{ steps.deploy.outputs.static_web_app_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: app-build
+          path: dist/
+
+      - name: Deploy to Azure Static Web Apps
+        id: deploy
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: 'upload'
+          app_location: '/'
+          api_location: 'api'
+          output_location: 'dist'
+          skip_app_build: true
+
+  close_pull_request:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    name: Close PR Preview
+    steps:
+      - name: Close Pull Request Preview
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+          action: 'close'

--- a/azure.yaml
+++ b/azure.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
+
+name: citypulse-labs
+metadata:
+  template: citypulse-labs-bicicoruña@0.1.0
+
+infra:
+  provider: bicep
+  path: ./infra
+
+services:
+  web:
+    project: ./src/web
+    dist: dist
+    language: js
+    host: staticwebapp
+
+  api:
+    project: ./api
+    language: js
+    host: function

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,0 +1,130 @@
+targetScope = 'subscription'
+
+// ──────────────────────────────────────────────────────────────────────────────
+// CityPulse Labs — BiciCoruña Azure Infrastructure
+// SWA (Free) + Functions (Consumption) + Cosmos DB (Serverless) + App Insights
+// Target: €6–15/mo typical | Budget ceiling: €100/mo
+// ──────────────────────────────────────────────────────────────────────────────
+
+@minLength(1)
+@maxLength(64)
+@description('Environment name used to generate unique resource names (e.g., dev, prod)')
+param environmentName string
+
+@minLength(1)
+@description('Primary location for all resources')
+param location string = 'westeurope'
+
+@description('Contact email for budget alerts')
+param budgetContactEmail string = ''
+
+// Optional overrides
+param resourceGroupName string = ''
+param staticWebAppName string = ''
+param cosmosAccountName string = ''
+param applicationInsightsName string = ''
+param logAnalyticsName string = ''
+param functionAppName string = ''
+param appServicePlanName string = ''
+param storageAccountName string = ''
+
+var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
+var tags = {
+  project: 'citypulse-labs'
+  product: 'bicicoruña'
+  'managed-by': 'syntax-sorcery'
+  environment: environmentName
+  'azd-env-name': environmentName
+}
+
+// ─── Resource Group ──────────────────────────────────────────────────────────
+
+resource rg 'Microsoft.Resources/resourceGroups@2024-03-01' = {
+  name: !empty(resourceGroupName) ? resourceGroupName : 'rg-citypulse-${environmentName}'
+  location: location
+  tags: tags
+}
+
+// ─── Static Web App (Free tier) ─────────────────────────────────────────────
+
+module swa 'modules/static-web-app.bicep' = {
+  name: 'static-web-app'
+  scope: rg
+  params: {
+    name: !empty(staticWebAppName) ? staticWebAppName : 'swa-citypulse-${resourceToken}'
+    location: location
+    tags: union(tags, { 'azd-service-name': 'web' })
+  }
+}
+
+// ─── Cosmos DB (Serverless, NoSQL API) ──────────────────────────────────────
+
+module cosmos 'modules/cosmos.bicep' = {
+  name: 'cosmos-db'
+  scope: rg
+  params: {
+    accountName: !empty(cosmosAccountName) ? cosmosAccountName : 'cosmos-citypulse-${resourceToken}'
+    location: location
+    tags: tags
+  }
+}
+
+// ─── Functions (Consumption plan) ───────────────────────────────────────────
+
+module functions 'modules/functions.bicep' = {
+  name: 'functions'
+  scope: rg
+  params: {
+    functionAppName: !empty(functionAppName) ? functionAppName : 'func-citypulse-${resourceToken}'
+    appServicePlanName: !empty(appServicePlanName) ? appServicePlanName : 'plan-citypulse-${resourceToken}'
+    storageAccountName: !empty(storageAccountName) ? storageAccountName : 'stcitypulse${resourceToken}'
+    location: location
+    tags: union(tags, { 'azd-service-name': 'api' })
+    applicationInsightsConnectionString: monitoring.outputs.applicationInsightsConnectionString
+    cosmosAccountEndpoint: cosmos.outputs.endpoint
+    cosmosAccountName: cosmos.outputs.accountName
+    staticWebAppDefaultHostname: swa.outputs.defaultHostname
+  }
+}
+
+// ─── Monitoring (Application Insights + Log Analytics) ──────────────────────
+
+module monitoring 'modules/monitoring.bicep' = {
+  name: 'monitoring'
+  scope: rg
+  params: {
+    applicationInsightsName: !empty(applicationInsightsName) ? applicationInsightsName : 'appi-citypulse-${resourceToken}'
+    logAnalyticsName: !empty(logAnalyticsName) ? logAnalyticsName : 'log-citypulse-${resourceToken}'
+    location: location
+    tags: tags
+  }
+}
+
+// ─── Budget alerts (€100/mo ceiling) ────────────────────────────────────────
+
+module budget 'modules/budget.bicep' = {
+  name: 'budget-alerts'
+  scope: rg
+  params: {
+    budgetName: 'budget-citypulse-${environmentName}'
+    budgetAmount: 100
+    contactEmail: budgetContactEmail
+  }
+}
+
+// ─── Outputs ────────────────────────────────────────────────────────────────
+
+output AZURE_LOCATION string = location
+output AZURE_RESOURCE_GROUP string = rg.name
+
+output SWA_NAME string = swa.outputs.name
+output SWA_DEFAULT_HOSTNAME string = swa.outputs.defaultHostname
+output SWA_URL string = 'https://${swa.outputs.defaultHostname}'
+
+output COSMOS_ENDPOINT string = cosmos.outputs.endpoint
+output COSMOS_DATABASE_NAME string = cosmos.outputs.databaseName
+
+output FUNCTION_APP_NAME string = functions.outputs.functionAppName
+output FUNCTION_APP_URL string = functions.outputs.functionAppUrl
+
+output APPLICATIONINSIGHTS_CONNECTION_STRING string = monitoring.outputs.applicationInsightsConnectionString

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "environmentName": {
+      "value": "${AZURE_ENV_NAME}"
+    },
+    "location": {
+      "value": "${AZURE_LOCATION}"
+    },
+    "budgetContactEmail": {
+      "value": ""
+    }
+  }
+}

--- a/infra/modules/budget.bicep
+++ b/infra/modules/budget.bicep
@@ -1,0 +1,65 @@
+// ──────────────────────────────────────────────────────────────────────────────
+// Budget Alerts — €100/mo ceiling with escalating notifications
+// Alerts at €30 (30%), €60 (60%), €90 (90%)
+// ──────────────────────────────────────────────────────────────────────────────
+
+@description('Budget resource name')
+param budgetName string
+
+@description('Monthly budget amount in EUR')
+param budgetAmount int = 100
+
+@description('Contact email for budget notifications (leave empty to skip action group)')
+param contactEmail string = ''
+
+@description('Start date for budget tracking (first day of current month)')
+param startDate string = utcNow('yyyy-MM-01')
+
+// ─── Budget ─────────────────────────────────────────────────────────────────
+
+resource budget 'Microsoft.Consumption/budgets@2023-11-01' = {
+  name: budgetName
+  properties: {
+    category: 'Cost'
+    amount: budgetAmount
+    timeGrain: 'Monthly'
+    timePeriod: {
+      startDate: startDate
+    }
+    notifications: {
+      warning30: {
+        enabled: true
+        operator: 'GreaterThanOrEqualTo'
+        threshold: 30
+        thresholdType: 'Actual'
+        contactRoles: [
+          'Owner'
+          'Contributor'
+        ]
+        contactEmails: !empty(contactEmail) ? [contactEmail] : []
+      }
+      warning60: {
+        enabled: true
+        operator: 'GreaterThanOrEqualTo'
+        threshold: 60
+        thresholdType: 'Actual'
+        contactRoles: [
+          'Owner'
+          'Contributor'
+        ]
+        contactEmails: !empty(contactEmail) ? [contactEmail] : []
+      }
+      critical90: {
+        enabled: true
+        operator: 'GreaterThanOrEqualTo'
+        threshold: 90
+        thresholdType: 'Actual'
+        contactRoles: [
+          'Owner'
+          'Contributor'
+        ]
+        contactEmails: !empty(contactEmail) ? [contactEmail] : []
+      }
+    }
+  }
+}

--- a/infra/modules/cosmos.bicep
+++ b/infra/modules/cosmos.bicep
@@ -1,0 +1,98 @@
+// ──────────────────────────────────────────────────────────────────────────────
+// Cosmos DB — Serverless, NoSQL API
+// Database: bici-coruna | Container: station-snapshots
+// Partition key: /stationId | TTL: 90 days (7776000s)
+// Estimated cost: €5–12/mo (pay-per-request, no provisioned RU/s)
+// ──────────────────────────────────────────────────────────────────────────────
+
+@description('Cosmos DB account name')
+param accountName string
+
+@description('Location for the Cosmos DB account')
+param location string = resourceGroup().location
+
+@description('Tags to apply to all resources')
+param tags object = {}
+
+@description('Database name')
+param databaseName string = 'bici-coruna'
+
+@description('Station snapshots container name')
+param containerName string = 'station-snapshots'
+
+@description('Partition key path for station snapshots')
+param partitionKeyPath string = '/stationId'
+
+@description('Default TTL in seconds (90 days = 7776000)')
+param defaultTtl int = 7776000
+
+// ─── Cosmos DB Account (Serverless) ─────────────────────────────────────────
+
+resource cosmosAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
+  name: accountName
+  location: location
+  tags: tags
+  kind: 'GlobalDocumentDB'
+  properties: {
+    databaseAccountOfferType: 'Standard'
+    locations: [
+      {
+        locationName: location
+        failoverPriority: 0
+        isZoneRedundant: false
+      }
+    ]
+    capabilities: [
+      { name: 'EnableServerless' }
+    ]
+    consistencyPolicy: {
+      defaultConsistencyLevel: 'Session'
+    }
+    enableFreeTier: false
+  }
+}
+
+// ─── SQL Database ───────────────────────────────────────────────────────────
+
+resource database 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-05-15' = {
+  parent: cosmosAccount
+  name: databaseName
+  properties: {
+    resource: {
+      id: databaseName
+    }
+  }
+}
+
+// ─── Station Snapshots Container ────────────────────────────────────────────
+
+resource container 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-05-15' = {
+  parent: database
+  name: containerName
+  properties: {
+    resource: {
+      id: containerName
+      partitionKey: {
+        paths: [partitionKeyPath]
+        kind: 'Hash'
+      }
+      defaultTtl: defaultTtl
+      indexingPolicy: {
+        indexingMode: 'consistent'
+        automatic: true
+        includedPaths: [
+          { path: '/*' }
+        ]
+        excludedPaths: [
+          { path: '/"_etag"/?' }
+        ]
+      }
+    }
+  }
+}
+
+// ─── Outputs ────────────────────────────────────────────────────────────────
+
+output accountName string = cosmosAccount.name
+output endpoint string = cosmosAccount.properties.documentEndpoint
+output databaseName string = database.name

--- a/infra/modules/functions.bicep
+++ b/infra/modules/functions.bicep
@@ -1,0 +1,124 @@
+// ──────────────────────────────────────────────────────────────────────────────
+// Azure Functions — Consumption plan (Y1/Dynamic)
+// Standalone Function App for Timer Triggers (data collection)
+// SWA integrated functions handle API requests; this handles background jobs
+// Estimated cost: €1–3/mo (Consumption plan, low invocation count)
+// ──────────────────────────────────────────────────────────────────────────────
+
+@description('Function App name')
+param functionAppName string
+
+@description('App Service Plan name')
+param appServicePlanName string
+
+@description('Storage account name for Functions runtime')
+param storageAccountName string
+
+@description('Location for resources')
+param location string = resourceGroup().location
+
+@description('Tags to apply')
+param tags object = {}
+
+@description('Application Insights connection string')
+param applicationInsightsConnectionString string
+
+@description('Cosmos DB account endpoint')
+param cosmosAccountEndpoint string
+
+@description('Cosmos DB account name (for RBAC role assignment)')
+param cosmosAccountName string
+
+@description('SWA default hostname for CORS')
+param staticWebAppDefaultHostname string
+
+// ─── Storage Account (Functions runtime backing store) ──────────────────────
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: storageAccountName
+  location: location
+  tags: tags
+  kind: 'StorageV2'
+  sku: {
+    name: 'Standard_LRS'
+  }
+  properties: {
+    supportsHttpsTrafficOnly: true
+    minimumTlsVersion: 'TLS1_2'
+    allowBlobPublicAccess: false
+  }
+}
+
+// ─── App Service Plan (Consumption / Dynamic) ──────────────────────────────
+
+resource appServicePlan 'Microsoft.Web/serverfarms@2023-12-01' = {
+  name: appServicePlanName
+  location: location
+  tags: tags
+  kind: 'functionapp'
+  sku: {
+    name: 'Y1'
+    tier: 'Dynamic'
+  }
+  properties: {
+    reserved: true
+  }
+}
+
+// ─── Function App ───────────────────────────────────────────────────────────
+
+resource functionApp 'Microsoft.Web/sites@2023-12-01' = {
+  name: functionAppName
+  location: location
+  tags: tags
+  kind: 'functionapp,linux'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    serverFarmId: appServicePlan.id
+    httpsOnly: true
+    siteConfig: {
+      linuxFxVersion: 'Node|22'
+      appSettings: [
+        { name: 'AzureWebJobsStorage', value: 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storageAccount.listKeys().keys[0].value}' }
+        { name: 'WEBSITE_CONTENTAZUREFILECONNECTIONSTRING', value: 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storageAccount.listKeys().keys[0].value}' }
+        { name: 'WEBSITE_CONTENTSHARE', value: toLower(functionAppName) }
+        { name: 'FUNCTIONS_EXTENSION_VERSION', value: '~4' }
+        { name: 'FUNCTIONS_WORKER_RUNTIME', value: 'node' }
+        { name: 'WEBSITE_NODE_DEFAULT_VERSION', value: '~22' }
+        { name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: applicationInsightsConnectionString }
+        { name: 'COSMOS_ENDPOINT', value: cosmosAccountEndpoint }
+        { name: 'COSMOS_DATABASE_NAME', value: 'bici-coruna' }
+      ]
+      cors: {
+        allowedOrigins: [
+          'https://${staticWebAppDefaultHostname}'
+        ]
+      }
+    }
+  }
+}
+
+// ─── Cosmos DB Data Contributor role for Function App (managed identity) ────
+
+resource cosmosAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' existing = {
+  name: cosmosAccountName
+}
+
+// Built-in role: Cosmos DB Built-in Data Contributor
+resource cosmosRoleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2024-05-15' = {
+  parent: cosmosAccount
+  name: guid(cosmosAccount.id, functionApp.id, '00000000-0000-0000-0000-000000000002')
+  properties: {
+    roleDefinitionId: '${cosmosAccount.id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002'
+    principalId: functionApp.identity.principalId
+    scope: cosmosAccount.id
+  }
+}
+
+// ─── Outputs ────────────────────────────────────────────────────────────────
+
+output functionAppName string = functionApp.name
+output functionAppUrl string = 'https://${functionApp.properties.defaultHostName}'
+output functionAppPrincipalId string = functionApp.identity.principalId

--- a/infra/modules/monitoring.bicep
+++ b/infra/modules/monitoring.bicep
@@ -1,0 +1,54 @@
+// ──────────────────────────────────────────────────────────────────────────────
+// Monitoring — Application Insights + Log Analytics
+// Free tier: 5 GB/month ingestion included
+// Estimated cost: €0 (within free allowance for prototype traffic)
+// ──────────────────────────────────────────────────────────────────────────────
+
+@description('Application Insights resource name')
+param applicationInsightsName string
+
+@description('Log Analytics workspace name')
+param logAnalyticsName string
+
+@description('Location for monitoring resources')
+param location string = resourceGroup().location
+
+@description('Tags to apply to all resources')
+param tags object = {}
+
+// ─── Log Analytics Workspace ────────────────────────────────────────────────
+
+resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+  name: logAnalyticsName
+  location: location
+  tags: tags
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 30
+    workspaceCapping: {
+      dailyQuotaGb: 1
+    }
+  }
+}
+
+// ─── Application Insights ───────────────────────────────────────────────────
+
+resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: applicationInsightsName
+  location: location
+  tags: tags
+  kind: 'web'
+  properties: {
+    Application_Type: 'web'
+    WorkspaceResourceId: logAnalytics.id
+    RetentionInDays: 30
+  }
+}
+
+// ─── Outputs ────────────────────────────────────────────────────────────────
+
+output applicationInsightsConnectionString string = applicationInsights.properties.ConnectionString
+output applicationInsightsId string = applicationInsights.id
+output logAnalyticsWorkspaceId string = logAnalytics.id

--- a/infra/modules/static-web-app.bicep
+++ b/infra/modules/static-web-app.bicep
@@ -1,0 +1,41 @@
+// ──────────────────────────────────────────────────────────────────────────────
+// Azure Static Web App — Free tier
+// Includes integrated Azure Functions for API
+// Estimated cost: €0/mo (Free tier)
+// ──────────────────────────────────────────────────────────────────────────────
+
+@description('Static Web App name')
+param name string
+
+@description('Location for the Static Web App')
+param location string = resourceGroup().location
+
+@description('Tags to apply')
+param tags object = {}
+
+// ─── Static Web App ─────────────────────────────────────────────────────────
+
+resource staticWebApp 'Microsoft.Web/staticSites@2023-12-01' = {
+  name: name
+  location: location
+  tags: tags
+  sku: {
+    name: 'Free'
+    tier: 'Free'
+  }
+  properties: {
+    stagingEnvironmentPolicy: 'Enabled'
+    allowConfigFileUpdates: true
+    buildProperties: {
+      appLocation: '/'
+      apiLocation: 'api'
+      outputLocation: 'dist'
+    }
+  }
+}
+
+// ─── Outputs ────────────────────────────────────────────────────────────────
+
+output name string = staticWebApp.name
+output defaultHostname string = staticWebApp.properties.defaultHostname
+output id string = staticWebApp.id


### PR DESCRIPTION
Closes #2 and #7

## Azure Bicep IaC for BiciCoruña

**Resources provisioned (all westeurope):**
- **Azure Static Web Apps** — Free tier (€0/mo)
- **Azure Functions** — Consumption plan Y1/Dynamic (€1–3/mo)
- **Cosmos DB** — Serverless NoSQL API (€5–12/mo)
  - Database: \ici-coruna\
  - Container: \station-snapshots\ (partition: \/stationId\, TTL: 90 days)
- **Application Insights** + Log Analytics (€0, within free 5GB)
- **Budget alerts** at €30/€60/€90 (€100/mo ceiling)

**CI/CD pipeline** (\.github/workflows/azure-swa.yml\):
- Build + test + deploy to SWA on push to main
- Preview environments on PRs (auto-cleanup on close)
- Uses \AZURE_STATIC_WEB_APPS_API_TOKEN\ secret

**azd support:** \zure.yaml\ configured for \zd up\ deployment

**Estimated monthly cost:** €6–15 typical | €100 hard ceiling

⚠️ Do NOT merge until #1 (scaffolding) is merged first.