### PR TITLE
feat: #5 Multi-modal route calculator — walk-bike-walk with top 3 routes

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -15,6 +15,14 @@ vi.mock('react-leaflet', () => ({
   Popup: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="popup">{children}</div>
   ),
+  Marker: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="marker">{children}</div>
+  ),
+  Polyline: () => <div data-testid="polyline" />,
+  Tooltip: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="tooltip">{children}</div>
+  ),
+  useMapEvents: () => null,
 }));
 
 // Mock useStations hook
@@ -27,10 +35,20 @@ vi.mock('./hooks/useStations', () => ({
   }),
 }));
 
+// Mock useRoutes hook
+vi.mock('./hooks/useRoutes', () => ({
+  useRoutes: () => ({
+    routes: [],
+    walkingRoute: null,
+    loading: false,
+    error: null,
+  }),
+}));
+
 describe('App', () => {
-  it('renders the BiciCoruña header', () => {
+  it('renders the BiciCoru\u00F1a header', () => {
     render(<App />);
-    expect(screen.getByText(/BiciCoruña/)).toBeInTheDocument();
+    expect(screen.getByText(/BiciCoru\u00F1a/)).toBeInTheDocument();
   });
 
   it('renders the map container', () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,27 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import MapView from './components/Map/MapView.tsx';
 import StationPanel from './components/StationPanel/StationPanel.tsx';
+import RoutePanel from './components/RoutePanel/RoutePanel.tsx';
 import { useStations } from './hooks/useStations.ts';
-import type { StationData } from './types/index.ts';
+import { useRoutes } from './hooks/useRoutes.ts';
+import type { StationData, LatLng } from './types/index.ts';
 
 function App() {
   const { stations, loading, error, lastUpdated } = useStations();
   const [selectedStation, setSelectedStation] = useState<StationData | null>(null);
+  const [origin, setOrigin] = useState<LatLng | null>(null);
+  const [destination, setDestination] = useState<LatLng | null>(null);
+  const [selectedRouteIndex, setSelectedRouteIndex] = useState(0);
+
+  const { routes, walkingRoute, loading: routeLoading, error: routeError } = useRoutes(origin, destination, stations);
+
+  const handleClearRoute = useCallback(() => {
+    setOrigin(null);
+    setDestination(null);
+    setSelectedRouteIndex(0);
+  }, []);
+
+  const selectedRoute = routes[selectedRouteIndex] ?? null;
 
   return (
     <div className="h-screen w-screen flex flex-col">
@@ -23,19 +38,33 @@ function App() {
             selectedStationId={selectedStation?.station_id}
             onStationSelect={setSelectedStation}
             lastUpdated={lastUpdated}
+            origin={origin}
+            destination={destination}
+            selectedRoute={selectedRoute}
+            onSetOrigin={setOrigin}
+            onSetDestination={setDestination}
+            onClearRoute={handleClearRoute}
           />
         </main>
 
-        {/* Station panel — sidebar on desktop, bottom sheet on mobile */}
+        {/* Sidebar */}
         <aside
           className={`
-            ${selectedStation ? 'block' : 'hidden lg:block'}
+            ${selectedStation || origin || destination ? 'block' : 'hidden lg:block'}
             lg:w-80 lg:border-l lg:border-gray-200 lg:relative
             ${selectedStation ? 'panel-mobile lg:panel-mobile-reset' : ''}
             bg-white overflow-y-auto
           `}
           style={selectedStation ? { zIndex: 40 } : undefined}
         >
+          <RoutePanel
+            routes={routes}
+            walkingRoute={walkingRoute}
+            loading={routeLoading}
+            error={routeError}
+            selectedIndex={selectedRouteIndex}
+            onSelectRoute={setSelectedRouteIndex}
+          />
           <StationPanel
             station={selectedStation}
             loading={loading}

--- a/src/components/Map/LocationPicker.tsx
+++ b/src/components/Map/LocationPicker.tsx
@@ -1,0 +1,96 @@
+import { useMapEvents, Marker, Popup } from 'react-leaflet';
+import L from 'leaflet';
+import type { LatLng } from '../../types/index.ts';
+
+interface LocationPickerProps {
+  origin: LatLng | null;
+  destination: LatLng | null;
+  onSetOrigin: (point: LatLng) => void;
+  onSetDestination: (point: LatLng) => void;
+  onClear: () => void;
+}
+
+const originIcon = new L.Icon({
+  iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-green.png',
+  shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png',
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  shadowSize: [41, 41],
+});
+
+const destinationIcon = new L.Icon({
+  iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png',
+  shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png',
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  shadowSize: [41, 41],
+});
+
+function MapClickHandler({
+  origin,
+  onSetOrigin,
+  onSetDestination,
+}: Pick<LocationPickerProps, 'origin' | 'onSetOrigin' | 'onSetDestination'>) {
+  useMapEvents({
+    click(e) {
+      const point: LatLng = { lat: e.latlng.lat, lng: e.latlng.lng };
+      if (!origin) {
+        onSetOrigin(point);
+      } else {
+        onSetDestination(point);
+      }
+    },
+  });
+  return null;
+}
+
+export default function LocationPicker({
+  origin,
+  destination,
+  onSetOrigin,
+  onSetDestination,
+  onClear,
+}: LocationPickerProps) {
+  const instructionText = !origin
+    ? 'Haz clic en el mapa para marcar el origen'
+    : !destination
+      ? 'Haz clic en el mapa para marcar el destino'
+      : null;
+
+  return (
+    <>
+      <MapClickHandler origin={origin} onSetOrigin={onSetOrigin} onSetDestination={onSetDestination} />
+
+      {instructionText && (
+        <div className="absolute top-2 left-1/2 -translate-x-1/2 z-[1000] bg-white px-4 py-2 rounded-lg shadow-md text-sm font-medium">
+          {instructionText}
+        </div>
+      )}
+
+      {(origin || destination) && (
+        <div className="absolute top-2 right-2 z-[1000]">
+          <button
+            onClick={onClear}
+            className="bg-white px-3 py-1.5 rounded-lg shadow-md text-sm font-medium text-red-600 hover:bg-red-50 transition-colors"
+          >
+            Borrar ruta
+          </button>
+        </div>
+      )}
+
+      {origin && (
+        <Marker position={[origin.lat, origin.lng]} icon={originIcon}>
+          <Popup>Origen</Popup>
+        </Marker>
+      )}
+
+      {destination && (
+        <Marker position={[destination.lat, destination.lng]} icon={destinationIcon}>
+          <Popup>Destino</Popup>
+        </Marker>
+      )}
+    </>
+  );
+}

--- a/src/components/Map/MapView.tsx
+++ b/src/components/Map/MapView.tsx
@@ -1,8 +1,10 @@
 import { MapContainer, TileLayer, ZoomControl } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
-import type { StationData } from '../../types/index.ts';
+import type { StationData, LatLng, MultiModalRoute } from '../../types/index.ts';
 import StationMarkers from './StationMarkers.tsx';
 import LiveIndicator from './LiveIndicator.tsx';
+import LocationPicker from './LocationPicker.tsx';
+import RouteDisplay from './RouteDisplay.tsx';
 
 const A_CORUNA_CENTER = { lat: 43.3623, lng: -8.4115 };
 const DEFAULT_ZOOM = 14;
@@ -12,6 +14,12 @@ interface MapViewProps {
   selectedStationId?: string | null;
   onStationSelect?: (station: StationData) => void;
   lastUpdated: Date | null;
+  origin: LatLng | null;
+  destination: LatLng | null;
+  selectedRoute: MultiModalRoute | null;
+  onSetOrigin: (point: LatLng) => void;
+  onSetDestination: (point: LatLng) => void;
+  onClearRoute: () => void;
 }
 
 export default function MapView({
@@ -19,6 +27,12 @@ export default function MapView({
   selectedStationId,
   onStationSelect,
   lastUpdated,
+  origin,
+  destination,
+  selectedRoute,
+  onSetOrigin,
+  onSetDestination,
+  onClearRoute,
 }: MapViewProps) {
   return (
     <div className="relative h-full w-full">
@@ -39,6 +53,14 @@ export default function MapView({
           selectedStationId={selectedStationId}
           onStationSelect={onStationSelect}
         />
+        <LocationPicker
+          origin={origin}
+          destination={destination}
+          onSetOrigin={onSetOrigin}
+          onSetDestination={onSetDestination}
+          onClear={onClearRoute}
+        />
+        <RouteDisplay route={selectedRoute} />
       </MapContainer>
     </div>
   );

--- a/src/components/Map/RouteDisplay.tsx
+++ b/src/components/Map/RouteDisplay.tsx
@@ -1,0 +1,54 @@
+import { Polyline, CircleMarker, Tooltip } from 'react-leaflet';
+import type { MultiModalRoute } from '../../types/index.ts';
+
+interface RouteDisplayProps {
+  route: MultiModalRoute | null;
+}
+
+export default function RouteDisplay({ route }: RouteDisplayProps) {
+  if (!route) return null;
+
+  return (
+    <>
+      {/* Walk to pickup - dashed blue */}
+      <Polyline
+        positions={route.walk_to_pickup.geometry}
+        pathOptions={{ color: '#3B82F6', weight: 4, dashArray: '8 6', opacity: 0.8 }}
+      />
+
+      {/* Bike segment - solid green */}
+      <Polyline
+        positions={route.bike_segment.geometry}
+        pathOptions={{ color: '#22C55E', weight: 5, opacity: 0.9 }}
+      />
+
+      {/* Walk to destination - dashed blue */}
+      <Polyline
+        positions={route.walk_to_destination.geometry}
+        pathOptions={{ color: '#3B82F6', weight: 4, dashArray: '8 6', opacity: 0.8 }}
+      />
+
+      {/* Pickup station marker */}
+      <CircleMarker
+        center={[route.pickup_station.lat, route.pickup_station.lon]}
+        radius={8}
+        pathOptions={{ color: '#22C55E', fillColor: '#22C55E', fillOpacity: 0.9, weight: 2 }}
+      >
+        <Tooltip permanent direction="top" offset={[0, -10]}>
+          {route.pickup_station.name}
+        </Tooltip>
+      </CircleMarker>
+
+      {/* Dropoff station marker */}
+      <CircleMarker
+        center={[route.dropoff_station.lat, route.dropoff_station.lon]}
+        radius={8}
+        pathOptions={{ color: '#EF4444', fillColor: '#EF4444', fillOpacity: 0.9, weight: 2 }}
+      >
+        <Tooltip permanent direction="top" offset={[0, -10]}>
+          {route.dropoff_station.name}
+        </Tooltip>
+      </CircleMarker>
+    </>
+  );
+}

--- a/src/components/RoutePanel/RoutePanel.tsx
+++ b/src/components/RoutePanel/RoutePanel.tsx
@@ -1,8 +1,128 @@
-export default function RoutePanel() {
+import type { MultiModalRoute, WalkingRoute } from '../../types/index.ts';
+
+interface RoutePanelProps {
+  routes: MultiModalRoute[];
+  walkingRoute: WalkingRoute | null;
+  loading: boolean;
+  error: string | null;
+  selectedIndex: number;
+  onSelectRoute: (index: number) => void;
+}
+
+function formatTime(seconds: number): string {
+  const mins = Math.round(seconds / 60);
+  if (mins < 1) return '< 1 min';
+  return `${mins} min`;
+}
+
+function formatDistance(meters: number): string {
+  if (meters < 1000) return `${Math.round(meters)} m`;
+  return `${(meters / 1000).toFixed(1)} km`;
+}
+
+function RouteCard({
+  route,
+  walkingRoute,
+  index,
+  isSelected,
+  onSelect,
+}: {
+  route: MultiModalRoute;
+  walkingRoute: WalkingRoute | null;
+  index: number;
+  isSelected: boolean;
+  onSelect: () => void;
+}) {
+  const bikeMinutes = Math.round(route.total_time_seconds / 60);
+  const walkMinutes = walkingRoute ? Math.round(walkingRoute.total_time_seconds / 60) : null;
+  const timeSaved = walkMinutes ? walkMinutes - bikeMinutes : null;
+
   return (
-    <div className="p-4">
-      <h2 className="text-lg font-semibold">Routes</h2>
-      <p className="text-sm text-gray-500">Route planner coming soon.</p>
+    <button
+      onClick={onSelect}
+      className={`w-full text-left p-3 rounded-lg border-2 transition-colors ${
+        isSelected
+          ? 'border-blue-500 bg-blue-50'
+          : 'border-gray-200 bg-white hover:border-gray-300'
+      }`}
+    >
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-xs font-medium text-gray-500">Ruta {index + 1}</span>
+        <span className="text-lg font-bold text-gray-900">{formatTime(route.total_time_seconds)}</span>
+      </div>
+
+      <div className="flex gap-3 text-xs text-gray-600 mb-2">
+        <span>🚶 {formatTime(route.walk_time_seconds)} ({formatDistance(route.walk_distance_meters)})</span>
+        <span>🚲 {formatTime(route.bike_time_seconds)} ({formatDistance(route.bike_distance_meters)})</span>
+      </div>
+
+      <div className="text-xs text-gray-500">
+        <div>📍 Recoger: {route.pickup_station.name}</div>
+        <div>🅿️ Dejar: {route.dropoff_station.name}</div>
+      </div>
+
+      {timeSaved !== null && (
+        <div className={`mt-2 text-xs font-medium px-2 py-1 rounded ${
+          timeSaved > 0
+            ? 'bg-green-100 text-green-700'
+            : 'bg-amber-100 text-amber-700'
+        }`}>
+          {timeSaved > 0
+            ? `🚲 Bici: ${bikeMinutes} min | 🚶 Andando: ${walkMinutes} min | ⚡ Ahorras ${timeSaved} min`
+            : `🚶 Andando es más rápido (${walkMinutes} min vs ${bikeMinutes} min en bici)`}
+        </div>
+      )}
+    </button>
+  );
+}
+
+export default function RoutePanel({
+  routes,
+  walkingRoute,
+  loading,
+  error,
+  selectedIndex,
+  onSelectRoute,
+}: RoutePanelProps) {
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-lg font-semibold">🗺️ Rutas</h2>
+
+      {loading && (
+        <div className="flex items-center gap-2 text-sm text-gray-500">
+          <div className="animate-spin h-4 w-4 border-2 border-blue-500 border-t-transparent rounded-full" />
+          Calculando rutas...
+        </div>
+      )}
+
+      {error && (
+        <div className="text-sm text-red-600 bg-red-50 p-2 rounded">
+          ⚠️ {error}
+        </div>
+      )}
+
+      {!loading && !error && routes.length === 0 && (
+        <p className="text-sm text-gray-500">
+          Haz clic en el mapa para seleccionar origen y destino.
+        </p>
+      )}
+
+      {routes.map((route, i) => (
+        <RouteCard
+          key={`${route.pickup_station.station_id}-${route.dropoff_station.station_id}`}
+          route={route}
+          walkingRoute={walkingRoute}
+          index={i}
+          isSelected={i === selectedIndex}
+          onSelect={() => onSelectRoute(i)}
+        />
+      ))}
+
+      {walkingRoute && !loading && (
+        <div className="text-xs text-gray-500 border-t pt-2 mt-2">
+          🚶 Ruta directa andando: {formatTime(walkingRoute.total_time_seconds)} ({formatDistance(walkingRoute.total_distance_meters)})
+        </div>
+      )}
     </div>
   );
 }

--- a/src/hooks/useRoutes.ts
+++ b/src/hooks/useRoutes.ts
@@ -1,0 +1,63 @@
+import { useState, useEffect } from 'react';
+import type { LatLng, MultiModalRoute, WalkingRoute } from '../types/index.ts';
+import type { StationData } from '../types/gbfs.ts';
+import { calculateMultiModalRoutes, calculateWalkingOnly } from '../services/routeEngine.ts';
+
+interface UseRoutesResult {
+  routes: MultiModalRoute[];
+  walkingRoute: WalkingRoute | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export function useRoutes(
+  origin: LatLng | null,
+  destination: LatLng | null,
+  stations: StationData[],
+): UseRoutesResult {
+  const [routes, setRoutes] = useState<MultiModalRoute[]>([]);
+  const [walkingRoute, setWalkingRoute] = useState<WalkingRoute | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!origin || !destination) {
+      setRoutes([]);
+      setWalkingRoute(null);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    async function fetchRoutes() {
+      try {
+        const [multiModal, walking] = await Promise.all([
+          calculateMultiModalRoutes(origin!, destination!, stations),
+          calculateWalkingOnly(origin!, destination!),
+        ]);
+
+        if (!cancelled) {
+          setRoutes(multiModal);
+          setWalkingRoute(walking);
+          setLoading(false);
+        }
+      } catch (err: unknown) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to calculate routes');
+          setLoading(false);
+        }
+      }
+    }
+
+    fetchRoutes();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [origin, destination, stations]);
+
+  return { routes, walkingRoute, loading, error };
+}

--- a/src/services/routeEngine.ts
+++ b/src/services/routeEngine.ts
@@ -1,0 +1,142 @@
+import type { StationData } from '../types/gbfs.ts';
+import type { LatLng, MultiModalRoute, WalkingRoute, StationSummary } from '../types/index.ts';
+import { haversineDistance, getWalkingRoute, getCyclingRoute } from './routing.ts';
+
+const MAX_WALKING_DISTANCE_M = 1000;
+const TOP_N = 3;
+// Limit candidate pairs to avoid excessive API calls
+const MAX_CANDIDATES = 6;
+
+function toStationSummary(station: StationData): StationSummary {
+  return {
+    station_id: station.station_id,
+    name: station.name,
+    lat: station.lat,
+    lon: station.lon,
+  };
+}
+
+/** Filter stations that have bikes available and are within walking distance of a point */
+export function filterPickupStations(
+  stations: StationData[],
+  origin: LatLng,
+  maxDistance = MAX_WALKING_DISTANCE_M,
+): StationData[] {
+  return stations
+    .filter(
+      (s) =>
+        s.num_bikes_available > 0 &&
+        s.is_renting &&
+        haversineDistance(origin.lat, origin.lng, s.lat, s.lon) <= maxDistance,
+    )
+    .sort(
+      (a, b) =>
+        haversineDistance(origin.lat, origin.lng, a.lat, a.lon) -
+        haversineDistance(origin.lat, origin.lng, b.lat, b.lon),
+    );
+}
+
+/** Filter stations that have docks available and are within walking distance of a point */
+export function filterDropoffStations(
+  stations: StationData[],
+  destination: LatLng,
+  maxDistance = MAX_WALKING_DISTANCE_M,
+): StationData[] {
+  return stations
+    .filter(
+      (s) =>
+        s.num_docks_available > 0 &&
+        s.is_returning &&
+        haversineDistance(destination.lat, destination.lng, s.lat, s.lon) <= maxDistance,
+    )
+    .sort(
+      (a, b) =>
+        haversineDistance(destination.lat, destination.lng, a.lat, a.lon) -
+        haversineDistance(destination.lat, destination.lng, b.lat, b.lon),
+    );
+}
+
+/** Calculate multi-modal routes: walk -> bike -> walk */
+export async function calculateMultiModalRoutes(
+  origin: LatLng,
+  destination: LatLng,
+  stations: StationData[],
+): Promise<MultiModalRoute[]> {
+  const pickups = filterPickupStations(stations, origin).slice(0, MAX_CANDIDATES);
+  const dropoffs = filterDropoffStations(stations, destination).slice(0, MAX_CANDIDATES);
+
+  if (pickups.length === 0 || dropoffs.length === 0) {
+    return [];
+  }
+
+  // Build candidate pairs, limited to avoid rate limiting
+  const pairs: { pickup: StationData; dropoff: StationData }[] = [];
+  for (const pickup of pickups) {
+    for (const dropoff of dropoffs) {
+      if (pickup.station_id !== dropoff.station_id) {
+        pairs.push({ pickup, dropoff });
+      }
+    }
+  }
+
+  // Sort by estimated total straight-line distance and take top candidates
+  const sortedPairs = pairs
+    .map((p) => ({
+      ...p,
+      estimatedDist:
+        haversineDistance(origin.lat, origin.lng, p.pickup.lat, p.pickup.lon) +
+        haversineDistance(p.pickup.lat, p.pickup.lon, p.dropoff.lat, p.dropoff.lon) +
+        haversineDistance(p.dropoff.lat, p.dropoff.lon, destination.lat, destination.lng),
+    }))
+    .sort((a, b) => a.estimatedDist - b.estimatedDist)
+    .slice(0, MAX_CANDIDATES);
+
+  const routes: MultiModalRoute[] = [];
+
+  for (const { pickup, dropoff } of sortedPairs) {
+    try {
+      const pickupLatLng: LatLng = { lat: pickup.lat, lng: pickup.lon };
+      const dropoffLatLng: LatLng = { lat: dropoff.lat, lng: dropoff.lon };
+
+      const [walkToPickup, bikeSegment, walkToDest] = await Promise.all([
+        getWalkingRoute(origin, pickupLatLng),
+        getCyclingRoute(pickupLatLng, dropoffLatLng),
+        getWalkingRoute(dropoffLatLng, destination),
+      ]);
+
+      const walkTime = walkToPickup.duration_seconds + walkToDest.duration_seconds;
+      const bikeTime = bikeSegment.duration_seconds;
+
+      routes.push({
+        pickup_station: toStationSummary(pickup),
+        dropoff_station: toStationSummary(dropoff),
+        walk_to_pickup: walkToPickup,
+        bike_segment: bikeSegment,
+        walk_to_destination: walkToDest,
+        total_time_seconds: walkTime + bikeTime,
+        walk_time_seconds: walkTime,
+        bike_time_seconds: bikeTime,
+        walk_distance_meters: walkToPickup.distance_meters + walkToDest.distance_meters,
+        bike_distance_meters: bikeSegment.distance_meters,
+      });
+    } catch {
+      // Skip failed route calculations
+      continue;
+    }
+  }
+
+  return routes.sort((a, b) => a.total_time_seconds - b.total_time_seconds).slice(0, TOP_N);
+}
+
+/** Calculate a direct walking route for comparison */
+export async function calculateWalkingOnly(
+  origin: LatLng,
+  destination: LatLng,
+): Promise<WalkingRoute> {
+  const segment = await getWalkingRoute(origin, destination);
+  return {
+    segment,
+    total_time_seconds: segment.duration_seconds,
+    total_distance_meters: segment.distance_meters,
+  };
+}

--- a/src/services/routing.ts
+++ b/src/services/routing.ts
@@ -1,4 +1,8 @@
-import type { StationData, Route } from '../types/index.ts';
+import type { LatLng, RouteSegment } from '../types/index.ts';
+
+const ORS_BASE_URL = 'https://api.openrouteservice.org/v2/directions';
+
+type ORSProfile = 'foot-walking' | 'cycling-regular';
 
 /** Calculate distance between two points using Haversine formula */
 export function haversineDistance(
@@ -15,13 +19,67 @@ export function haversineDistance(
   return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 }
 
-/** Find the top N bike-sharing routes between origin and destination */
-export function findRoutes(
-  _origin: { lat: number; lng: number },
-  _destination: { lat: number; lng: number },
-  _stations: StationData[],
-  _topN = 3,
-): Route[] {
-  // TODO: Implement multi-modal routing (walk → bike → walk)
-  return [];
+function getApiKey(): string {
+  return (
+    (typeof import.meta !== 'undefined' && import.meta.env?.VITE_ORS_API_KEY) || ''
+  );
+}
+
+async function fetchRoute(
+  profile: ORSProfile,
+  from: LatLng,
+  to: LatLng,
+): Promise<RouteSegment> {
+  const apiKey = getApiKey();
+  // ORS expects [lng, lat] order
+  const start = `${from.lng},${from.lat}`;
+  const end = `${to.lng},${to.lat}`;
+
+  const headers: Record<string, string> = {
+    'Accept': 'application/json, application/geo+json',
+  };
+  if (apiKey) {
+    headers['Authorization'] = apiKey;
+  }
+
+  const url = `${ORS_BASE_URL}/${profile}?start=${start}&end=${end}`;
+  const response = await fetch(url, { headers });
+
+  if (!response.ok) {
+    throw new Error(`ORS API error: ${response.status} ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  const feature = data.features?.[0];
+  if (!feature) {
+    throw new Error('No route found');
+  }
+
+  const { distance, duration } = feature.properties.summary;
+  // GeoJSON coordinates are [lng, lat]; convert to [lat, lng]
+  const geometry: [number, number][] = feature.geometry.coordinates.map(
+    (coord: number[]) => [coord[1], coord[0]] as [number, number],
+  );
+
+  return {
+    geometry,
+    duration_seconds: duration,
+    distance_meters: distance,
+  };
+}
+
+/** Get a walking route between two points */
+export async function getWalkingRoute(
+  from: LatLng,
+  to: LatLng,
+): Promise<RouteSegment> {
+  return fetchRoute('foot-walking', from, to);
+}
+
+/** Get a cycling route between two points */
+export async function getCyclingRoute(
+  from: LatLng,
+  to: LatLng,
+): Promise<RouteSegment> {
+  return fetchRoute('cycling-regular', from, to);
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,6 +13,44 @@ export type {
 export type { StationInformation as StationInfo } from './gbfs.ts';
 export type { StationData as Station } from './gbfs.ts';
 
+export interface LatLng {
+  lat: number;
+  lng: number;
+}
+
+export interface RouteSegment {
+  geometry: [number, number][];
+  duration_seconds: number;
+  distance_meters: number;
+}
+
+export interface StationSummary {
+  station_id: string;
+  name: string;
+  lat: number;
+  lon: number;
+}
+
+export interface MultiModalRoute {
+  pickup_station: StationSummary;
+  dropoff_station: StationSummary;
+  walk_to_pickup: RouteSegment;
+  bike_segment: RouteSegment;
+  walk_to_destination: RouteSegment;
+  total_time_seconds: number;
+  walk_time_seconds: number;
+  bike_time_seconds: number;
+  walk_distance_meters: number;
+  bike_distance_meters: number;
+}
+
+export interface WalkingRoute {
+  segment: RouteSegment;
+  total_time_seconds: number;
+  total_distance_meters: number;
+}
+
+/** @deprecated Use MultiModalRoute instead */
 export interface Route {
   walkToStation: { station_id: string; name: string; lat: number; lon: number; capacity: number };
   bikeToStation: { station_id: string; name: string; lat: number; lon: number; capacity: number };

--- a/tests/unit/routeEngine.test.ts
+++ b/tests/unit/routeEngine.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { StationData } from '../../src/types/gbfs';
+import {
+  filterPickupStations,
+  filterDropoffStations,
+  calculateMultiModalRoutes,
+  calculateWalkingOnly,
+} from '../../src/services/routeEngine';
+import { haversineDistance } from '../../src/services/routing';
+
+// Mock the routing module's fetch-based functions
+vi.mock('../../src/services/routing', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../src/services/routing')>();
+  return {
+    ...original,
+    getWalkingRoute: vi.fn(),
+    getCyclingRoute: vi.fn(),
+  };
+});
+
+import { getWalkingRoute, getCyclingRoute } from '../../src/services/routing';
+
+const mockedGetWalkingRoute = vi.mocked(getWalkingRoute);
+const mockedGetCyclingRoute = vi.mocked(getCyclingRoute);
+
+// --- Mock station data -------------------------------------------------------
+
+function makeStation(overrides: Partial<StationData> & { station_id: string; name: string; lat: number; lon: number }): StationData {
+  return {
+    capacity: 20,
+    num_bikes_available: 5,
+    num_bikes_disabled: 0,
+    num_docks_available: 10,
+    num_docks_disabled: 0,
+    is_renting: true,
+    is_returning: true,
+    is_installed: true,
+    last_reported: Date.now(),
+    vehicle_types_available: [],
+    ...overrides,
+  };
+}
+
+// Stations near origin (43.362, -8.411) within ~500m
+const stationNearOrigin = makeStation({
+  station_id: 'pickup-1',
+  name: 'Plaza Mayor',
+  lat: 43.3630,
+  lon: -8.4120,
+  num_bikes_available: 8,
+  num_docks_available: 5,
+});
+
+const stationNearOrigin2 = makeStation({
+  station_id: 'pickup-2',
+  name: 'Parque Europa',
+  lat: 43.3625,
+  lon: -8.4100,
+  num_bikes_available: 3,
+  num_docks_available: 12,
+});
+
+// Station near destination (43.370, -8.400) within ~500m
+const stationNearDest = makeStation({
+  station_id: 'dropoff-1',
+  name: 'Marina',
+  lat: 43.3710,
+  lon: -8.4010,
+  num_bikes_available: 2,
+  num_docks_available: 15,
+});
+
+const stationNearDest2 = makeStation({
+  station_id: 'dropoff-2',
+  name: 'Puerto',
+  lat: 43.3695,
+  lon: -8.3990,
+  num_bikes_available: 0,
+  num_docks_available: 8,
+});
+
+// Station with no bikes
+const stationNoBikes = makeStation({
+  station_id: 'empty-1',
+  name: 'Vacia',
+  lat: 43.3628,
+  lon: -8.4118,
+  num_bikes_available: 0,
+  num_docks_available: 20,
+});
+
+// Station with no docks
+const stationNoDocks = makeStation({
+  station_id: 'full-1',
+  name: 'Llena',
+  lat: 43.3705,
+  lon: -8.4005,
+  num_bikes_available: 20,
+  num_docks_available: 0,
+});
+
+// Station far from everything (>2km)
+const stationFarAway = makeStation({
+  station_id: 'far-1',
+  name: 'Lejos',
+  lat: 43.390,
+  lon: -8.430,
+  num_bikes_available: 10,
+  num_docks_available: 10,
+});
+
+// Station not renting
+const stationNotRenting = makeStation({
+  station_id: 'offline-1',
+  name: 'Offline',
+  lat: 43.3632,
+  lon: -8.4115,
+  is_renting: false,
+  num_bikes_available: 5,
+});
+
+const allStations = [
+  stationNearOrigin,
+  stationNearOrigin2,
+  stationNearDest,
+  stationNearDest2,
+  stationNoBikes,
+  stationNoDocks,
+  stationFarAway,
+  stationNotRenting,
+];
+
+const origin = { lat: 43.362, lng: -8.411 };
+const destination = { lat: 43.370, lng: -8.400 };
+
+// --- Tests -------------------------------------------------------------------
+
+describe('haversineDistance', () => {
+  it('returns 0 for same point', () => {
+    expect(haversineDistance(43.362, -8.411, 43.362, -8.411)).toBe(0);
+  });
+
+  it('calculates reasonable distance between nearby points', () => {
+    const dist = haversineDistance(43.362, -8.411, 43.370, -8.400);
+    expect(dist).toBeGreaterThan(800);
+    expect(dist).toBeLessThan(1500);
+  });
+});
+
+describe('filterPickupStations', () => {
+  it('only includes stations with bikes available', () => {
+    const result = filterPickupStations(allStations, origin);
+    const ids = result.map((s) => s.station_id);
+    expect(ids).not.toContain('empty-1');
+  });
+
+  it('only includes stations that are renting', () => {
+    const result = filterPickupStations(allStations, origin);
+    const ids = result.map((s) => s.station_id);
+    expect(ids).not.toContain('offline-1');
+  });
+
+  it('excludes stations beyond max walking distance', () => {
+    const result = filterPickupStations(allStations, origin);
+    const ids = result.map((s) => s.station_id);
+    expect(ids).not.toContain('far-1');
+  });
+
+  it('includes valid nearby stations', () => {
+    const result = filterPickupStations(allStations, origin);
+    const ids = result.map((s) => s.station_id);
+    expect(ids).toContain('pickup-1');
+    expect(ids).toContain('pickup-2');
+  });
+
+  it('sorts by distance from origin (closest first)', () => {
+    const result = filterPickupStations(allStations, origin);
+    if (result.length >= 2) {
+      const dist0 = haversineDistance(origin.lat, origin.lng, result[0].lat, result[0].lon);
+      const dist1 = haversineDistance(origin.lat, origin.lng, result[1].lat, result[1].lon);
+      expect(dist0).toBeLessThanOrEqual(dist1);
+    }
+  });
+});
+
+describe('filterDropoffStations', () => {
+  it('only includes stations with docks available', () => {
+    const result = filterDropoffStations(allStations, destination);
+    const ids = result.map((s) => s.station_id);
+    expect(ids).not.toContain('full-1');
+  });
+
+  it('includes valid nearby stations with docks', () => {
+    const result = filterDropoffStations(allStations, destination);
+    const ids = result.map((s) => s.station_id);
+    expect(ids).toContain('dropoff-1');
+    expect(ids).toContain('dropoff-2');
+  });
+
+  it('excludes stations beyond max walking distance', () => {
+    const result = filterDropoffStations(allStations, destination);
+    const ids = result.map((s) => s.station_id);
+    expect(ids).not.toContain('far-1');
+  });
+});
+
+describe('calculateMultiModalRoutes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function mockRouteResponse(durationSeconds: number, distanceMeters: number) {
+    return {
+      geometry: [[43.36, -8.41] as [number, number], [43.37, -8.40] as [number, number]],
+      duration_seconds: durationSeconds,
+      distance_meters: distanceMeters,
+    };
+  }
+
+  it('returns empty array when no pickup stations available', async () => {
+    const stationsNoBikes = allStations.map((s) => ({ ...s, num_bikes_available: 0 }));
+    const result = await calculateMultiModalRoutes(origin, destination, stationsNoBikes);
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when no dropoff stations available', async () => {
+    const stationsNoDocks = allStations.map((s) => ({ ...s, num_docks_available: 0 }));
+    const result = await calculateMultiModalRoutes(origin, destination, stationsNoDocks);
+    expect(result).toEqual([]);
+  });
+
+  it('returns routes sorted by total time (shortest first)', async () => {
+    mockedGetWalkingRoute
+      .mockResolvedValueOnce(mockRouteResponse(120, 200))
+      .mockResolvedValueOnce(mockRouteResponse(300, 500))
+      .mockResolvedValueOnce(mockRouteResponse(90, 150))
+      .mockResolvedValueOnce(mockRouteResponse(180, 300));
+
+    mockedGetCyclingRoute
+      .mockResolvedValueOnce(mockRouteResponse(600, 2000))
+      .mockResolvedValueOnce(mockRouteResponse(400, 1500));
+
+    const result = await calculateMultiModalRoutes(origin, destination, allStations);
+
+    expect(result.length).toBeGreaterThan(0);
+    expect(result.length).toBeLessThanOrEqual(3);
+
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i].total_time_seconds).toBeGreaterThanOrEqual(result[i - 1].total_time_seconds);
+    }
+  });
+
+  it('includes correct station info in results', async () => {
+    mockedGetWalkingRoute.mockResolvedValue(mockRouteResponse(120, 200));
+    mockedGetCyclingRoute.mockResolvedValue(mockRouteResponse(300, 1000));
+
+    const result = await calculateMultiModalRoutes(origin, destination, allStations);
+
+    if (result.length > 0) {
+      const route = result[0];
+      expect(route.pickup_station).toHaveProperty('station_id');
+      expect(route.pickup_station).toHaveProperty('name');
+      expect(route.dropoff_station).toHaveProperty('station_id');
+      expect(route.dropoff_station).toHaveProperty('name');
+    }
+  });
+
+  it('calculates walk and bike time/distance correctly', async () => {
+    mockedGetWalkingRoute
+      .mockResolvedValueOnce(mockRouteResponse(100, 150))
+      .mockResolvedValueOnce(mockRouteResponse(200, 300));
+    mockedGetCyclingRoute
+      .mockResolvedValueOnce(mockRouteResponse(400, 2000));
+
+    const limitedStations = [stationNearOrigin, stationNearDest];
+    const result = await calculateMultiModalRoutes(origin, destination, limitedStations);
+
+    expect(result.length).toBe(1);
+    const route = result[0];
+    expect(route.walk_time_seconds).toBe(300);
+    expect(route.bike_time_seconds).toBe(400);
+    expect(route.total_time_seconds).toBe(700);
+    expect(route.walk_distance_meters).toBe(450);
+    expect(route.bike_distance_meters).toBe(2000);
+  });
+
+  it('returns at most 3 routes', async () => {
+    mockedGetWalkingRoute.mockResolvedValue(mockRouteResponse(100, 150));
+    mockedGetCyclingRoute.mockResolvedValue(mockRouteResponse(300, 1000));
+
+    const result = await calculateMultiModalRoutes(origin, destination, allStations);
+    expect(result.length).toBeLessThanOrEqual(3);
+  });
+
+  it('handles API failures gracefully by skipping failed routes', async () => {
+    mockedGetWalkingRoute
+      .mockRejectedValueOnce(new Error('API error'))
+      .mockResolvedValue(mockRouteResponse(100, 150));
+    mockedGetCyclingRoute.mockResolvedValue(mockRouteResponse(300, 1000));
+
+    const result = await calculateMultiModalRoutes(origin, destination, allStations);
+    expect(Array.isArray(result)).toBe(true);
+  });
+});
+
+describe('calculateWalkingOnly', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns walking route with correct time and distance', async () => {
+    mockedGetWalkingRoute.mockResolvedValue({
+      geometry: [[43.362, -8.411] as [number, number], [43.370, -8.400] as [number, number]],
+      duration_seconds: 1680,
+      distance_meters: 1400,
+    });
+
+    const result = await calculateWalkingOnly(origin, destination);
+    expect(result.total_time_seconds).toBe(1680);
+    expect(result.total_distance_meters).toBe(1400);
+    expect(result.segment.geometry).toHaveLength(2);
+  });
+});
+
+describe('walking comparison logic', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('bike route faster than walking shows positive time savings', async () => {
+    mockedGetWalkingRoute
+      .mockResolvedValueOnce({
+        geometry: [[0, 0] as [number, number]],
+        duration_seconds: 120,
+        distance_meters: 100,
+      })
+      .mockResolvedValueOnce({
+        geometry: [[0, 0] as [number, number]],
+        duration_seconds: 120,
+        distance_meters: 100,
+      })
+      .mockResolvedValueOnce({
+        geometry: [[0, 0] as [number, number]],
+        duration_seconds: 1680,
+        distance_meters: 1400,
+      });
+    mockedGetCyclingRoute.mockResolvedValue({
+      geometry: [[0, 0] as [number, number]],
+      duration_seconds: 480,
+      distance_meters: 2000,
+    });
+
+    const limitedStations = [stationNearOrigin, stationNearDest];
+    const [routes, walking] = await Promise.all([
+      calculateMultiModalRoutes(origin, destination, limitedStations),
+      calculateWalkingOnly(origin, destination),
+    ]);
+
+    if (routes.length > 0 && walking) {
+      const bikeMinutes = Math.round(routes[0].total_time_seconds / 60);
+      const walkMinutes = Math.round(walking.total_time_seconds / 60);
+      const timeSaved = walkMinutes - bikeMinutes;
+      expect(timeSaved).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Implements the multi-modal route calculator for issue #5.

### What's new

- **Routing service** (\src/services/routing.ts\): openrouteservice API integration with \getWalkingRoute()\ and \getCyclingRoute()\
- **Route engine** (\src/services/routeEngine.ts\): \calculateMultiModalRoutes()\ filters pickup/dropoff stations by availability and walking distance, scores by total time, returns top 3
- **Route hook** (\src/hooks/useRoutes.ts\): React hook that calls the route engine when origin AND destination are set
- **Route panel** (\src/components/RoutePanel/RoutePanel.tsx\): Displays top 3 route suggestions with walk/bike time breakdown and walking comparison
- **Location picker** (\src/components/Map/LocationPicker.tsx\): Click-to-set origin/destination markers with clear button
- **Route display** (\src/components/Map/RouteDisplay.tsx\): Leaflet polylines with dashed blue (walk) and solid green (bike) segments
- **Tests** (\	ests/unit/routeEngine.test.ts\): 19 unit tests covering station filtering, route scoring, time/distance calculation, walking comparison, and error handling

### Configuration

Set \VITE_ORS_API_KEY\ environment variable for openrouteservice API key (free tier).

### Tests

All 63 tests pass (19 new + 44 existing).

Closes #5