### PR TITLE
feat: Geofencing zones overlay

### DIFF
--- a/src/components/Map/GeofencingOverlay.tsx
+++ b/src/components/Map/GeofencingOverlay.tsx
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+import { GeoJSON } from 'react-leaflet';
+import type { Layer, PathOptions } from 'leaflet';
+import type { GeofencingZonesCollection } from '../../types/index.ts';
+import {
+  parseGeofencingFeatures,
+  classifyZone,
+  getZoneStyle,
+  getZoneTooltip,
+} from '../../services/geofencing.ts';
+
+interface GeofencingOverlayProps {
+  zones: GeofencingZonesCollection | null;
+  loading: boolean;
+}
+
+export default function GeofencingOverlay({
+  zones,
+  loading,
+}: GeofencingOverlayProps) {
+  const [visible, setVisible] = useState(true);
+
+  if (loading) return null;
+
+  const hasZones = zones && parseGeofencingFeatures(zones).length > 0;
+
+  return (
+    <>
+      {/* Toggle control */}
+      <div className="absolute bottom-24 left-3 z-[1000]">
+        <button
+          onClick={() => setVisible((v) => !v)}
+          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg shadow-md text-xs font-medium transition-colors ${
+            visible
+              ? 'bg-green-600 text-white hover:bg-green-700'
+              : 'bg-white text-gray-600 hover:bg-gray-50'
+          }`}
+          title="Toggle geofencing zones"
+        >
+          <span className="text-sm">📍</span>
+          Zones
+        </button>
+      </div>
+
+      {/* Zones layer */}
+      {visible && hasZones && (
+        <GeoJSON
+          key={JSON.stringify(zones)}
+          data={zones!}
+          style={(feature) => {
+            if (!feature) return {};
+            const classification = classifyZone(feature as any);
+            return getZoneStyle(classification) as PathOptions;
+          }}
+          onEachFeature={(feature, layer: Layer) => {
+            const tooltip = getZoneTooltip(feature as any);
+            layer.bindTooltip(tooltip, {
+              sticky: true,
+              direction: 'top',
+              className: 'geofencing-tooltip',
+            });
+          }}
+        />
+      )}
+
+      {/* No zones message */}
+      {visible && !hasZones && !loading && (
+        <div className="absolute bottom-36 left-3 z-[1000] bg-white/90 px-3 py-2 rounded-lg shadow-md text-xs text-gray-500 max-w-48">
+          No geofencing zones available for this system
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/Map/MapView.tsx
+++ b/src/components/Map/MapView.tsx
@@ -5,6 +5,8 @@ import StationMarkers from './StationMarkers.tsx';
 import LiveIndicator from './LiveIndicator.tsx';
 import LocationPicker from './LocationPicker.tsx';
 import RouteDisplay from './RouteDisplay.tsx';
+import GeofencingOverlay from './GeofencingOverlay.tsx';
+import { useGeofencing } from '../../hooks/useGeofencing.ts';
 
 const A_CORUNA_CENTER = { lat: 43.3623, lng: -8.4115 };
 const DEFAULT_ZOOM = 14;
@@ -34,6 +36,8 @@ export default function MapView({
   onSetDestination,
   onClearRoute,
 }: MapViewProps) {
+  const { zones, loading: zonesLoading } = useGeofencing();
+
   return (
     <div className="relative h-full w-full">
       <LiveIndicator lastUpdated={lastUpdated} />
@@ -48,6 +52,7 @@ export default function MapView({
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
+        <GeofencingOverlay zones={zones} loading={zonesLoading} />
         <StationMarkers
           stations={stations}
           selectedStationId={selectedStationId}

--- a/src/hooks/useGeofencing.ts
+++ b/src/hooks/useGeofencing.ts
@@ -1,0 +1,50 @@
+import { useState, useEffect } from 'react';
+import type { GeofencingZonesCollection } from '../types/index.ts';
+import {
+  discoverGeofencingUrl,
+  fetchGeofencingZones,
+} from '../services/geofencing.ts';
+
+export function useGeofencing() {
+  const [zones, setZones] = useState<GeofencingZonesCollection | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadZones() {
+      try {
+        const url = await discoverGeofencingUrl();
+        if (!url) {
+          if (!cancelled) {
+            setZones(null);
+            setLoading(false);
+          }
+          return;
+        }
+
+        const data = await fetchGeofencingZones(url);
+        if (!cancelled) {
+          setZones(data);
+          setLoading(false);
+        }
+      } catch (err: unknown) {
+        if (!cancelled) {
+          setError(
+            err instanceof Error ? err.message : 'Failed to fetch geofencing zones',
+          );
+          setLoading(false);
+        }
+      }
+    }
+
+    loadZones();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { zones, loading, error };
+}

--- a/src/services/geofencing.ts
+++ b/src/services/geofencing.ts
@@ -1,0 +1,133 @@
+import type {
+  GBFSResponse,
+  GBFSDiscoveryData,
+  GBFSFeed,
+  GeofencingZonesCollection,
+  GeofencingZoneFeature,
+} from '../types/index.ts';
+
+const GBFS_DISCOVERY_URL =
+  'https://acoruna.publicbikesystem.net/customer/gbfs/v2/gbfs.json';
+const DEFAULT_LANGUAGE = 'en';
+
+/** Discover the geofencing_zones feed URL from the GBFS discovery endpoint */
+export async function discoverGeofencingUrl(
+  language = DEFAULT_LANGUAGE,
+): Promise<string | null> {
+  const res = await fetch(GBFS_DISCOVERY_URL);
+  if (!res.ok) throw new Error(`GBFS discovery failed: ${res.status}`);
+  const json: GBFSResponse<GBFSDiscoveryData> = await res.json();
+
+  const feeds =
+    json.data[language]?.feeds ?? json.data[Object.keys(json.data)[0]!]?.feeds;
+  if (!feeds) return null;
+
+  const geofencingFeed = feeds.find(
+    (f: GBFSFeed) => f.name === 'geofencing_zones',
+  );
+  return geofencingFeed?.url ?? null;
+}
+
+/** Fetch geofencing zones from the GBFS geofencing_zones endpoint */
+export async function fetchGeofencingZones(
+  url: string,
+): Promise<GeofencingZonesCollection> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`geofencing_zones fetch failed: ${res.status}`);
+  const json: GBFSResponse<{ geofencing_zones: GeofencingZonesCollection }> =
+    await res.json();
+  return json.data.geofencing_zones;
+}
+
+/** Parse and validate GeoJSON features from the zones collection */
+export function parseGeofencingFeatures(
+  collection: GeofencingZonesCollection,
+): GeofencingZoneFeature[] {
+  if (collection.type !== 'FeatureCollection') return [];
+  return collection.features.filter(
+    (f) =>
+      f.type === 'Feature' &&
+      f.geometry != null &&
+      (f.geometry.type === 'MultiPolygon' || f.geometry.type === 'Polygon') &&
+      f.properties != null,
+  );
+}
+
+/** Classify a zone based on its rules for styling purposes */
+export function classifyZone(
+  feature: GeofencingZoneFeature,
+): 'service-area' | 'restricted' | 'speed-limit' | 'no-parking' | 'unknown' {
+  const rules = feature.properties.rules;
+  if (!rules || rules.length === 0) return 'service-area';
+
+  for (const rule of rules) {
+    if (!rule.ride_allowed && !rule.ride_through_allowed) return 'restricted';
+    if (!rule.ride_allowed) return 'restricted';
+    if (rule.maximum_speed_kph != null) return 'speed-limit';
+    if (rule.station_parking === false) return 'no-parking';
+  }
+
+  return 'service-area';
+}
+
+/** Get style config for a zone classification */
+export function getZoneStyle(classification: ReturnType<typeof classifyZone>) {
+  const styles = {
+    'service-area': {
+      color: '#22C55E',
+      fillColor: '#22C55E',
+      fillOpacity: 0.1,
+      weight: 2,
+      dashArray: undefined as string | undefined,
+    },
+    restricted: {
+      color: '#EF4444',
+      fillColor: '#EF4444',
+      fillOpacity: 0.15,
+      weight: 2,
+      dashArray: '8 4',
+    },
+    'speed-limit': {
+      color: '#F59E0B',
+      fillColor: '#F59E0B',
+      fillOpacity: 0.1,
+      weight: 2,
+      dashArray: '4 4',
+    },
+    'no-parking': {
+      color: '#8B5CF6',
+      fillColor: '#8B5CF6',
+      fillOpacity: 0.12,
+      weight: 2,
+      dashArray: '6 3',
+    },
+    unknown: {
+      color: '#6B7280',
+      fillColor: '#6B7280',
+      fillOpacity: 0.08,
+      weight: 1,
+      dashArray: undefined as string | undefined,
+    },
+  };
+  return styles[classification];
+}
+
+/** Build a tooltip description from zone properties */
+export function getZoneTooltip(feature: GeofencingZoneFeature): string {
+  const name = feature.properties.name || 'Unnamed zone';
+  const rules = feature.properties.rules;
+  if (!rules || rules.length === 0) return name;
+
+  const descriptions: string[] = [name];
+  for (const rule of rules) {
+    if (!rule.ride_allowed) descriptions.push('🚫 Riding not allowed');
+    else if (!rule.ride_through_allowed)
+      descriptions.push('⚠️ Ride-through not allowed');
+    if (rule.maximum_speed_kph != null)
+      descriptions.push(`🏎️ Max speed: ${rule.maximum_speed_kph} km/h`);
+    if (rule.station_parking === false)
+      descriptions.push('🅿️ No parking');
+  }
+
+  return descriptions.join('\n');
+}

--- a/src/types/gbfs.ts
+++ b/src/types/gbfs.ts
@@ -74,3 +74,36 @@ export interface GBFSDiscoveryData {
     feeds: GBFSFeed[];
   };
 }
+
+// --- Geofencing zones (GBFS v2) ---
+
+/** Rule applied to a geofencing zone */
+export interface GeofencingRule {
+  ride_allowed: boolean;
+  ride_through_allowed: boolean;
+  maximum_speed_kph?: number;
+  station_parking?: boolean;
+  vehicle_type_id?: string[];
+}
+
+/** Properties attached to a geofencing zone feature */
+export interface GeofencingZoneProperties {
+  name: string;
+  rules?: GeofencingRule[];
+}
+
+/** A single GeoJSON feature representing a geofencing zone */
+export interface GeofencingZoneFeature {
+  type: 'Feature';
+  geometry: {
+    type: 'MultiPolygon' | 'Polygon';
+    coordinates: number[][][][] | number[][][];
+  };
+  properties: GeofencingZoneProperties;
+}
+
+/** GeoJSON FeatureCollection of geofencing zones */
+export interface GeofencingZonesCollection {
+  type: 'FeatureCollection';
+  features: GeofencingZoneFeature[];
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,6 +7,10 @@ export type {
   GBFSDiscoveryData,
   VehicleTypeAvailable,
   VehicleDockAvailable,
+  GeofencingRule,
+  GeofencingZoneProperties,
+  GeofencingZoneFeature,
+  GeofencingZonesCollection,
 } from './gbfs.ts';
 
 // Backward-compatible aliases

--- a/tests/unit/geofencing.test.tsx
+++ b/tests/unit/geofencing.test.tsx
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type {
+  GeofencingZonesCollection,
+  GeofencingZoneFeature,
+} from '../../src/types/gbfs';
+import {
+  parseGeofencingFeatures,
+  classifyZone,
+  getZoneStyle,
+  getZoneTooltip,
+} from '../../src/services/geofencing';
+
+// --- Mock data ---------------------------------------------------------------
+
+const makeFeature = (
+  name: string,
+  rules?: GeofencingZoneFeature['properties']['rules'],
+  geometryType: 'MultiPolygon' | 'Polygon' = 'MultiPolygon',
+): GeofencingZoneFeature => ({
+  type: 'Feature',
+  geometry: {
+    type: geometryType,
+    coordinates:
+      geometryType === 'MultiPolygon'
+        ? [[[[-8.42, 43.36], [-8.40, 43.36], [-8.40, 43.37], [-8.42, 43.37], [-8.42, 43.36]]]]
+        : [[[-8.42, 43.36], [-8.40, 43.36], [-8.40, 43.37], [-8.42, 43.37], [-8.42, 43.36]]],
+  },
+  properties: { name, rules },
+});
+
+const mockServiceArea = makeFeature('A Coruña Service Area', [
+  { ride_allowed: true, ride_through_allowed: true },
+]);
+
+const mockRestrictedZone = makeFeature('Port Restricted Zone', [
+  { ride_allowed: false, ride_through_allowed: false },
+]);
+
+const mockSpeedLimitZone = makeFeature('Old Town Speed Limit', [
+  { ride_allowed: true, ride_through_allowed: true, maximum_speed_kph: 10 },
+]);
+
+const mockNoParkingZone = makeFeature('Plaza María Pita', [
+  { ride_allowed: true, ride_through_allowed: true, station_parking: false },
+]);
+
+const mockNoRulesZone = makeFeature('Default Zone');
+
+const mockCollection: GeofencingZonesCollection = {
+  type: 'FeatureCollection',
+  features: [
+    mockServiceArea,
+    mockRestrictedZone,
+    mockSpeedLimitZone,
+    mockNoParkingZone,
+  ],
+};
+
+const emptyCollection: GeofencingZonesCollection = {
+  type: 'FeatureCollection',
+  features: [],
+};
+
+// --- Tests: parseGeofencingFeatures ------------------------------------------
+
+describe('parseGeofencingFeatures', () => {
+  it('returns all valid features from a collection', () => {
+    const features = parseGeofencingFeatures(mockCollection);
+    expect(features).toHaveLength(4);
+  });
+
+  it('returns empty array for an empty FeatureCollection', () => {
+    const features = parseGeofencingFeatures(emptyCollection);
+    expect(features).toHaveLength(0);
+  });
+
+  it('filters out features with invalid type', () => {
+    const collection: GeofencingZonesCollection = {
+      type: 'FeatureCollection',
+      features: [
+        mockServiceArea,
+        { ...mockRestrictedZone, type: 'Invalid' as any },
+      ],
+    };
+    const features = parseGeofencingFeatures(collection);
+    expect(features).toHaveLength(1);
+    expect(features[0].properties.name).toBe('A Coruña Service Area');
+  });
+
+  it('filters out features with null geometry', () => {
+    const collection: GeofencingZonesCollection = {
+      type: 'FeatureCollection',
+      features: [
+        mockServiceArea,
+        { ...mockRestrictedZone, geometry: null as any },
+      ],
+    };
+    const features = parseGeofencingFeatures(collection);
+    expect(features).toHaveLength(1);
+  });
+
+  it('accepts both Polygon and MultiPolygon geometries', () => {
+    const polygonFeature = makeFeature('Polygon Zone', [], 'Polygon');
+    const collection: GeofencingZonesCollection = {
+      type: 'FeatureCollection',
+      features: [mockServiceArea, polygonFeature],
+    };
+    const features = parseGeofencingFeatures(collection);
+    expect(features).toHaveLength(2);
+  });
+
+  it('returns empty for non-FeatureCollection type', () => {
+    const bad = { type: 'Other', features: [mockServiceArea] } as any;
+    const features = parseGeofencingFeatures(bad);
+    expect(features).toHaveLength(0);
+  });
+});
+
+// --- Tests: classifyZone -----------------------------------------------------
+
+describe('classifyZone', () => {
+  it('classifies a service area zone', () => {
+    expect(classifyZone(mockServiceArea)).toBe('service-area');
+  });
+
+  it('classifies a restricted zone', () => {
+    expect(classifyZone(mockRestrictedZone)).toBe('restricted');
+  });
+
+  it('classifies a speed limit zone', () => {
+    expect(classifyZone(mockSpeedLimitZone)).toBe('speed-limit');
+  });
+
+  it('classifies a no-parking zone', () => {
+    expect(classifyZone(mockNoParkingZone)).toBe('no-parking');
+  });
+
+  it('defaults to service-area for zones without rules', () => {
+    expect(classifyZone(mockNoRulesZone)).toBe('service-area');
+  });
+
+  it('classifies as restricted when ride_allowed is false', () => {
+    const zone = makeFeature('Test', [
+      { ride_allowed: false, ride_through_allowed: true },
+    ]);
+    expect(classifyZone(zone)).toBe('restricted');
+  });
+});
+
+// --- Tests: getZoneStyle -----------------------------------------------------
+
+describe('getZoneStyle', () => {
+  it('returns green style for service-area', () => {
+    const style = getZoneStyle('service-area');
+    expect(style.color).toBe('#22C55E');
+    expect(style.fillOpacity).toBe(0.1);
+    expect(style.dashArray).toBeUndefined();
+  });
+
+  it('returns red dashed style for restricted', () => {
+    const style = getZoneStyle('restricted');
+    expect(style.color).toBe('#EF4444');
+    expect(style.fillOpacity).toBe(0.15);
+    expect(style.dashArray).toBe('8 4');
+  });
+
+  it('returns amber style for speed-limit', () => {
+    const style = getZoneStyle('speed-limit');
+    expect(style.color).toBe('#F59E0B');
+  });
+
+  it('returns purple style for no-parking', () => {
+    const style = getZoneStyle('no-parking');
+    expect(style.color).toBe('#8B5CF6');
+  });
+
+  it('returns gray style for unknown', () => {
+    const style = getZoneStyle('unknown');
+    expect(style.color).toBe('#6B7280');
+  });
+});
+
+// --- Tests: getZoneTooltip ---------------------------------------------------
+
+describe('getZoneTooltip', () => {
+  it('returns zone name for a zone without rules', () => {
+    expect(getZoneTooltip(mockNoRulesZone)).toBe('Default Zone');
+  });
+
+  it('includes riding restriction for restricted zone', () => {
+    const tooltip = getZoneTooltip(mockRestrictedZone);
+    expect(tooltip).toContain('Port Restricted Zone');
+    expect(tooltip).toContain('Riding not allowed');
+  });
+
+  it('includes speed limit info', () => {
+    const tooltip = getZoneTooltip(mockSpeedLimitZone);
+    expect(tooltip).toContain('Old Town Speed Limit');
+    expect(tooltip).toContain('10 km/h');
+  });
+
+  it('includes no parking info', () => {
+    const tooltip = getZoneTooltip(mockNoParkingZone);
+    expect(tooltip).toContain('No parking');
+  });
+
+  it('returns "Unnamed zone" when name is empty', () => {
+    const zone = makeFeature('', [{ ride_allowed: true, ride_through_allowed: true }]);
+    expect(getZoneTooltip(zone)).toContain('Unnamed zone');
+  });
+});
+
+// --- Tests: GeofencingOverlay component render --------------------------------
+
+// Mock react-leaflet to avoid Leaflet DOM initialization in jsdom
+vi.mock('react-leaflet', () => ({
+  GeoJSON: ({ data, style, onEachFeature }: any) => (
+    <div data-testid="geojson-layer" data-feature-count={data?.features?.length ?? 0} />
+  ),
+  Tooltip: ({ children }: any) => <span>{children}</span>,
+}));
+
+// Dynamic import after mock
+const { default: GeofencingOverlay } = await import(
+  '../../src/components/Map/GeofencingOverlay.tsx'
+);
+
+describe('GeofencingOverlay', () => {
+  it('renders toggle button', () => {
+    render(<GeofencingOverlay zones={mockCollection} loading={false} />);
+    expect(screen.getByText('Zones')).toBeInTheDocument();
+  });
+
+  it('renders GeoJSON layer when zones are available and visible', () => {
+    render(<GeofencingOverlay zones={mockCollection} loading={false} />);
+    expect(screen.getByTestId('geojson-layer')).toBeInTheDocument();
+  });
+
+  it('hides GeoJSON layer after clicking toggle', () => {
+    render(<GeofencingOverlay zones={mockCollection} loading={false} />);
+    fireEvent.click(screen.getByText('Zones'));
+    expect(screen.queryByTestId('geojson-layer')).not.toBeInTheDocument();
+  });
+
+  it('shows re-enabled GeoJSON layer after toggling twice', () => {
+    render(<GeofencingOverlay zones={mockCollection} loading={false} />);
+    const button = screen.getByText('Zones');
+    fireEvent.click(button);
+    fireEvent.click(button);
+    expect(screen.getByTestId('geojson-layer')).toBeInTheDocument();
+  });
+
+  it('shows "no zones available" when collection is empty', () => {
+    render(<GeofencingOverlay zones={emptyCollection} loading={false} />);
+    expect(screen.getByText(/no geofencing zones available/i)).toBeInTheDocument();
+  });
+
+  it('shows "no zones available" when zones is null', () => {
+    render(<GeofencingOverlay zones={null} loading={false} />);
+    expect(screen.getByText(/no geofencing zones available/i)).toBeInTheDocument();
+  });
+
+  it('renders nothing when loading', () => {
+    const { container } = render(
+      <GeofencingOverlay zones={null} loading={true} />,
+    );
+    expect(container.innerHTML).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

Implements geofencing zones overlay for the BiciCoruña map, fetching zone data from the GBFS v2 geofencing_zones endpoint.

### Changes

**Types** (src/types/gbfs.ts)
- Added GeofencingRule, GeofencingZoneProperties, GeofencingZoneFeature, GeofencingZonesCollection interfaces

**Service** (src/services/geofencing.ts)
- discoverGeofencingUrl() — discovers geofencing_zones feed from GBFS discovery endpoint
- fetchGeofencingZones() — fetches and parses zone data
- parseGeofencingFeatures() — validates GeoJSON features
- classifyZone() — categorizes zones as service-area/restricted/speed-limit/no-parking
- getZoneStyle() — returns color/fill/dash styling per classification
- getZoneTooltip() — builds hover tooltip with zone rules

**Hook** (src/hooks/useGeofencing.ts)
- useGeofencing() — fetches zones once on mount, returns { zones, loading, error }

**Component** (src/components/Map/GeofencingOverlay.tsx)
- Renders GeoJSON polygons on Leaflet map via react-leaflet
- Toggle button to show/hide zones
- Graceful "no zones available" fallback when endpoint returns empty features
- Tooltips on hover showing zone name and rules

**Integration** (src/components/Map/MapView.tsx)
- GeofencingOverlay rendered as first overlay layer inside MapContainer

**Tests** (tests/unit/geofencing.test.tsx)
- 29 tests covering GeoJSON parsing, zone classification, styling, tooltips, and component rendering

### Notes
- The BiciCoruna GBFS endpoint currently returns an empty FeatureCollection for geofencing_zones — the overlay gracefully handles this with a fallback message
- Zone styles: green (service area), red dashed (restricted), amber (speed limit), purple (no parking)

Closes #13