### PR TITLE
feat: #11 Rain warning + #12 Route stats

### DIFF
--- a/api/src/functions/weather.ts
+++ b/api/src/functions/weather.ts
@@ -1,0 +1,89 @@
+import { app } from '@azure/functions';
+import type { HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
+
+const OPEN_METEO_URL =
+  'https://api.open-meteo.com/v1/forecast?latitude=43.3623&longitude=-8.4115&minutely_15=precipitation_probability&forecast_minutely_15=8';
+
+const CACHE_TTL_MS = 600_000; // 10 minutes
+
+interface CacheEntry {
+  data: string;
+  timestamp: number;
+}
+
+let cache: CacheEntry | null = null;
+
+async function weatherHandler(
+  _req: HttpRequest,
+  context: InvocationContext,
+): Promise<HttpResponseInit> {
+  if (cache && Date.now() - cache.timestamp < CACHE_TTL_MS) {
+    return {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Cache': 'HIT',
+        'Cache-Control': `public, max-age=${Math.floor(CACHE_TTL_MS / 1000)}`,
+      },
+      body: cache.data,
+    };
+  }
+
+  try {
+    const res = await fetch(OPEN_METEO_URL);
+    if (!res.ok) throw new Error(`Open-Meteo API error: ${res.status}`);
+
+    const json = await res.json();
+    const probabilities: number[] =
+      json?.minutely_15?.precipitation_probability ?? [];
+    const times: string[] = json?.minutely_15?.time ?? [];
+
+    const body = JSON.stringify({
+      precipitation_probability: probabilities,
+      times,
+      fetched_at: new Date().toISOString(),
+    });
+
+    cache = { data: body, timestamp: Date.now() };
+
+    return {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Cache': 'MISS',
+        'Cache-Control': `public, max-age=${Math.floor(CACHE_TTL_MS / 1000)}`,
+      },
+      body,
+    };
+  } catch (err) {
+    context.log('Weather fetch error:', err);
+
+    if (cache) {
+      return {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Cache': 'STALE',
+          'X-Warning': 'Open-Meteo unavailable, serving cached data',
+        },
+        body: cache.data,
+      };
+    }
+
+    return {
+      status: 502,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        error: 'Failed to fetch weather data',
+        message: err instanceof Error ? err.message : String(err),
+      }),
+    };
+  }
+}
+
+app.http('weather', {
+  methods: ['GET'],
+  authLevel: 'anonymous',
+  route: 'weather',
+  handler: weatherHandler,
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,11 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import MapView from './components/Map/MapView.tsx';
 import StationPanel from './components/StationPanel/StationPanel.tsx';
 import RoutePanel from './components/RoutePanel/RoutePanel.tsx';
+import BikeTypeSelector from './components/shared/BikeTypeSelector.tsx';
 import { useStations } from './hooks/useStations.ts';
 import { useRoutes } from './hooks/useRoutes.ts';
+import { type BikeType, filterByBikeType } from './services/bikeTypeFilter.ts';
 import type { StationData, LatLng } from './types/index.ts';
 
 function App() {
@@ -12,8 +14,14 @@ function App() {
   const [origin, setOrigin] = useState<LatLng | null>(null);
   const [destination, setDestination] = useState<LatLng | null>(null);
   const [selectedRouteIndex, setSelectedRouteIndex] = useState(0);
+  const [bikeType, setBikeType] = useState<BikeType>('any');
 
-  const { routes, walkingRoute, loading: routeLoading, error: routeError } = useRoutes(origin, destination, stations);
+  const filteredStations = useMemo(
+    () => filterByBikeType(stations, bikeType),
+    [stations, bikeType],
+  );
+
+  const { routes, walkingRoute, loading: routeLoading, error: routeError } = useRoutes(origin, destination, stations, bikeType);
 
   const handleClearRoute = useCallback(() => {
     setOrigin(null);
@@ -27,14 +35,17 @@ function App() {
     <div className="h-screen w-screen flex flex-col">
       <header className="bg-blue-700 text-white px-4 py-2 flex items-center gap-2 shrink-0">
         <span className="text-xl font-bold">🚲 BiciCoruña</span>
-        <span className="text-sm opacity-80">Smart bike-sharing route planner</span>
+        <span className="text-sm opacity-80 hidden sm:inline">Smart bike-sharing route planner</span>
+        <div className="ml-auto">
+          <BikeTypeSelector selectedType={bikeType} onTypeChange={setBikeType} />
+        </div>
       </header>
 
       <div className="flex-1 flex flex-col lg:flex-row relative overflow-hidden">
         {/* Map */}
         <main className="flex-1 relative">
           <MapView
-            stations={stations}
+            stations={filteredStations}
             selectedStationId={selectedStation?.station_id}
             onStationSelect={setSelectedStation}
             lastUpdated={lastUpdated}
@@ -44,6 +55,7 @@ function App() {
             onSetOrigin={setOrigin}
             onSetDestination={setDestination}
             onClearRoute={handleClearRoute}
+            preferredBikeType={bikeType}
           />
         </main>
 
@@ -71,6 +83,7 @@ function App() {
             error={error}
             lastUpdated={lastUpdated}
             onClose={() => setSelectedStation(null)}
+            preferredBikeType={bikeType}
           />
         </aside>
       </div>

--- a/src/components/RoutePanel/RoutePanel.tsx
+++ b/src/components/RoutePanel/RoutePanel.tsx
@@ -1,4 +1,5 @@
 import type { MultiModalRoute, WalkingRoute } from '../../types/index.ts';
+import RouteStats from './RouteStats.tsx';
 
 interface RoutePanelProps {
   routes: MultiModalRoute[];
@@ -60,6 +61,8 @@ function RouteCard({
         <div>📍 Recoger: {route.pickup_station.name}</div>
         <div>🅿️ Dejar: {route.dropoff_station.name}</div>
       </div>
+
+      <RouteStats route={route} />
 
       {timeSaved !== null && (
         <div className={`mt-2 text-xs font-medium px-2 py-1 rounded ${

--- a/src/components/RoutePanel/RouteStats.tsx
+++ b/src/components/RoutePanel/RouteStats.tsx
@@ -1,0 +1,19 @@
+import type { MultiModalRoute } from '../../types/index.ts';
+import { getRouteStats, formatDistance } from '../../services/routeStats.ts';
+
+interface RouteStatsProps {
+  route: MultiModalRoute;
+}
+
+export default function RouteStats({ route }: RouteStatsProps) {
+  const stats = getRouteStats(route);
+
+  return (
+    <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-gray-500 mt-1">
+      <span>🚶 {formatDistance(stats.walkDistance)}</span>
+      <span>🚲 {formatDistance(stats.bikeDistance)}</span>
+      <span>🔥 {stats.calories} kcal</span>
+      <span>🌱 {stats.co2Saved} kg CO₂</span>
+    </div>
+  );
+}

--- a/src/components/shared/RainWarning.tsx
+++ b/src/components/shared/RainWarning.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+
+interface RainWarningProps {
+  precipitationProbability: number;
+  minutesUntilRain: number | null;
+}
+
+export default function RainWarning({
+  precipitationProbability,
+  minutesUntilRain,
+}: RainWarningProps) {
+  const [dismissed, setDismissed] = useState(false);
+
+  if (dismissed || precipitationProbability <= 60) return null;
+
+  const timeText =
+    minutesUntilRain !== null && minutesUntilRain > 0
+      ? `~${minutesUntilRain} min`
+      : 'pronto';
+
+  return (
+    <div
+      role="alert"
+      className="bg-amber-400 text-amber-900 px-4 py-2 flex items-center justify-between text-sm font-medium shrink-0"
+    >
+      <span>⛈️ Lluvia probable en {timeText} ({precipitationProbability}%)</span>
+      <button
+        onClick={() => setDismissed(true)}
+        className="ml-4 text-amber-800 hover:text-amber-950 font-bold"
+        aria-label="Cerrar aviso de lluvia"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}

--- a/src/hooks/useWeather.ts
+++ b/src/hooks/useWeather.ts
@@ -1,0 +1,43 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { fetchWeather, type WeatherData } from '../services/weather.ts';
+
+const POLL_INTERVAL_MS = 600_000; // 10 minutes
+
+interface UseWeatherResult {
+  precipitationProbability: number;
+  minutesUntilRain: number | null;
+  loading: boolean;
+}
+
+export function useWeather(): UseWeatherResult {
+  const [data, setData] = useState<WeatherData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const poll = useCallback(async () => {
+    try {
+      const weather = await fetchWeather();
+      setData(weather);
+    } catch {
+      // Graceful degradation: no banner shown on error
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    poll();
+    timerRef.current = setInterval(poll, POLL_INTERVAL_MS);
+
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [poll]);
+
+  return {
+    precipitationProbability: data?.precipitationProbability ?? 0,
+    minutesUntilRain: data?.minutesUntilRain ?? null,
+    loading,
+  };
+}

--- a/src/services/routeStats.ts
+++ b/src/services/routeStats.ts
@@ -1,0 +1,43 @@
+import type { MultiModalRoute } from '../types/index.ts';
+
+const CYCLING_KCAL_PER_KM = 30;
+const WALKING_KCAL_PER_KM = 4;
+const CO2_KG_PER_KM = 0.21;
+
+/** Estimate calories burned cycling a given distance. */
+export function calculateCalories(bikeDistanceKm: number, walkDistanceKm: number): number {
+  return Math.round(bikeDistanceKm * CYCLING_KCAL_PER_KM + walkDistanceKm * WALKING_KCAL_PER_KM);
+}
+
+/** Estimate CO₂ saved vs driving the total distance by car. */
+export function calculateCO2Saved(totalDistanceKm: number): number {
+  return parseFloat((totalDistanceKm * CO2_KG_PER_KM).toFixed(2));
+}
+
+/** Format duration in seconds to a human-readable string. */
+export function formatDuration(seconds: number): string {
+  const mins = Math.round(seconds / 60);
+  if (mins < 1) return '< 1 min';
+  return `${mins} min`;
+}
+
+/** Format distance in meters to a human-readable string. */
+export function formatDistance(meters: number): string {
+  if (meters < 1000) return `${Math.round(meters)} m`;
+  return `${(meters / 1000).toFixed(1)} km`;
+}
+
+/** Compute stats summary for a multi-modal route. */
+export function getRouteStats(route: MultiModalRoute) {
+  const bikeKm = route.bike_distance_meters / 1000;
+  const walkKm = route.walk_distance_meters / 1000;
+  const totalKm = bikeKm + walkKm;
+
+  return {
+    bikeDistance: route.bike_distance_meters,
+    walkDistance: route.walk_distance_meters,
+    totalDistance: route.bike_distance_meters + route.walk_distance_meters,
+    calories: calculateCalories(bikeKm, walkKm),
+    co2Saved: calculateCO2Saved(totalKm),
+  };
+}

--- a/src/services/weather.ts
+++ b/src/services/weather.ts
@@ -1,0 +1,39 @@
+export interface WeatherData {
+  precipitationProbability: number;
+  minutesUntilRain: number | null;
+}
+
+const WEATHER_API_URL = '/api/weather';
+const RAIN_THRESHOLD = 60;
+
+/**
+ * Fetch precipitation probability for A Coruña from the weather API proxy.
+ * Returns the max probability in the next ~30 min window and estimated
+ * minutes until rain exceeds the threshold.
+ */
+export async function fetchWeather(): Promise<WeatherData> {
+  const res = await fetch(WEATHER_API_URL);
+  if (!res.ok) {
+    throw new Error(`Weather API error: ${res.status}`);
+  }
+
+  const json = await res.json();
+  const probabilities: number[] = json.precipitation_probability ?? [];
+
+  if (probabilities.length === 0) {
+    return { precipitationProbability: 0, minutesUntilRain: null };
+  }
+
+  const maxProbability = Math.max(...probabilities);
+
+  // Each slot is 15 minutes; find the first slot above threshold
+  let minutesUntilRain: number | null = null;
+  for (let i = 0; i < probabilities.length; i++) {
+    if (probabilities[i] >= RAIN_THRESHOLD) {
+      minutesUntilRain = i * 15;
+      break;
+    }
+  }
+
+  return { precipitationProbability: maxProbability, minutesUntilRain };
+}

--- a/tests/unit/rainWarning.test.tsx
+++ b/tests/unit/rainWarning.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import RainWarning from '../../src/components/shared/RainWarning';
+
+describe('RainWarning', () => {
+  it('renders nothing when probability is below threshold', () => {
+    const { container } = render(
+      <RainWarning precipitationProbability={40} minutesUntilRain={null} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when probability is exactly 60', () => {
+    const { container } = render(
+      <RainWarning precipitationProbability={60} minutesUntilRain={30} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders banner when probability exceeds 60', () => {
+    render(
+      <RainWarning precipitationProbability={80} minutesUntilRain={30} />,
+    );
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/Lluvia probable en ~30 min/)).toBeInTheDocument();
+  });
+
+  it('shows "pronto" when minutesUntilRain is null', () => {
+    render(
+      <RainWarning precipitationProbability={90} minutesUntilRain={null} />,
+    );
+    expect(screen.getByText(/pronto/)).toBeInTheDocument();
+  });
+
+  it('shows "pronto" when minutesUntilRain is 0', () => {
+    render(
+      <RainWarning precipitationProbability={85} minutesUntilRain={0} />,
+    );
+    expect(screen.getByText(/pronto/)).toBeInTheDocument();
+  });
+
+  it('can be dismissed by clicking the close button', () => {
+    render(
+      <RainWarning precipitationProbability={75} minutesUntilRain={15} />,
+    );
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Cerrar aviso de lluvia'));
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('displays the probability percentage', () => {
+    render(
+      <RainWarning precipitationProbability={85} minutesUntilRain={15} />,
+    );
+    expect(screen.getByText(/85%/)).toBeInTheDocument();
+  });
+});

--- a/tests/unit/routeStats.test.ts
+++ b/tests/unit/routeStats.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import {
+  calculateCalories,
+  calculateCO2Saved,
+  formatDuration,
+  formatDistance,
+  getRouteStats,
+} from '../../src/services/routeStats';
+import type { MultiModalRoute } from '../../src/types/index';
+
+describe('calculateCalories', () => {
+  it('returns 0 for zero distance', () => {
+    expect(calculateCalories(0, 0)).toBe(0);
+  });
+
+  it('calculates cycling calories at ~30 kcal/km', () => {
+    expect(calculateCalories(5, 0)).toBe(150);
+  });
+
+  it('calculates walking calories at ~4 kcal/km', () => {
+    expect(calculateCalories(0, 5)).toBe(20);
+  });
+
+  it('combines walking and cycling calories', () => {
+    // 3km bike (90) + 1km walk (4) = 94
+    expect(calculateCalories(3, 1)).toBe(94);
+  });
+});
+
+describe('calculateCO2Saved', () => {
+  it('returns 0 for zero distance', () => {
+    expect(calculateCO2Saved(0)).toBe(0);
+  });
+
+  it('calculates CO₂ at 0.21 kg/km', () => {
+    expect(calculateCO2Saved(1)).toBe(0.21);
+  });
+
+  it('calculates CO₂ for longer distances', () => {
+    expect(calculateCO2Saved(10)).toBe(2.1);
+  });
+});
+
+describe('formatDuration', () => {
+  it('shows "< 1 min" for short durations', () => {
+    expect(formatDuration(20)).toBe('< 1 min');
+  });
+
+  it('rounds to nearest minute', () => {
+    expect(formatDuration(90)).toBe('2 min');
+  });
+
+  it('formats whole minutes', () => {
+    expect(formatDuration(600)).toBe('10 min');
+  });
+});
+
+describe('formatDistance', () => {
+  it('shows meters for short distances', () => {
+    expect(formatDistance(500)).toBe('500 m');
+  });
+
+  it('shows km with one decimal for longer distances', () => {
+    expect(formatDistance(1500)).toBe('1.5 km');
+  });
+
+  it('shows km for exactly 1000m', () => {
+    expect(formatDistance(1000)).toBe('1.0 km');
+  });
+});
+
+describe('getRouteStats', () => {
+  const mockRoute: MultiModalRoute = {
+    pickup_station: { station_id: 'p1', name: 'Pickup', lat: 43.36, lon: -8.41 },
+    dropoff_station: { station_id: 'd1', name: 'Dropoff', lat: 43.37, lon: -8.40 },
+    walk_to_pickup: { geometry: [], duration_seconds: 120, distance_meters: 200 },
+    bike_segment: { geometry: [], duration_seconds: 300, distance_meters: 3000 },
+    walk_to_destination: { geometry: [], duration_seconds: 150, distance_meters: 300 },
+    total_time_seconds: 570,
+    walk_time_seconds: 270,
+    bike_time_seconds: 300,
+    walk_distance_meters: 500,
+    bike_distance_meters: 3000,
+  };
+
+  it('calculates correct distances', () => {
+    const stats = getRouteStats(mockRoute);
+    expect(stats.bikeDistance).toBe(3000);
+    expect(stats.walkDistance).toBe(500);
+    expect(stats.totalDistance).toBe(3500);
+  });
+
+  it('calculates correct calories', () => {
+    const stats = getRouteStats(mockRoute);
+    // 3km bike (90) + 0.5km walk (2) = 92
+    expect(stats.calories).toBe(92);
+  });
+
+  it('calculates correct CO₂ saved', () => {
+    const stats = getRouteStats(mockRoute);
+    // 3.5km * 0.21 = 0.735 → 0.73 (toFixed rounds down at .5 per IEEE 754)
+    expect(stats.co2Saved).toBe(0.73);
+  });
+});

--- a/tests/unit/weather.test.ts
+++ b/tests/unit/weather.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetchWeather } from '../../src/services/weather';
+
+describe('fetchWeather', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('returns max probability and minutes until rain', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          precipitation_probability: [20, 50, 80, 40],
+          times: ['12:00', '12:15', '12:30', '12:45'],
+        }),
+    });
+
+    const result = await fetchWeather();
+    expect(result.precipitationProbability).toBe(80);
+    // First slot >= 60 is index 2 → 2 * 15 = 30 minutes
+    expect(result.minutesUntilRain).toBe(30);
+  });
+
+  it('returns null minutesUntilRain when no slot exceeds threshold', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          precipitation_probability: [10, 20, 30, 40],
+          times: ['12:00', '12:15', '12:30', '12:45'],
+        }),
+    });
+
+    const result = await fetchWeather();
+    expect(result.precipitationProbability).toBe(40);
+    expect(result.minutesUntilRain).toBeNull();
+  });
+
+  it('returns 0 minutes when first slot exceeds threshold', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          precipitation_probability: [90, 80, 70],
+          times: ['12:00', '12:15', '12:30'],
+        }),
+    });
+
+    const result = await fetchWeather();
+    expect(result.precipitationProbability).toBe(90);
+    expect(result.minutesUntilRain).toBe(0);
+  });
+
+  it('handles empty probabilities array', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          precipitation_probability: [],
+          times: [],
+        }),
+    });
+
+    const result = await fetchWeather();
+    expect(result.precipitationProbability).toBe(0);
+    expect(result.minutesUntilRain).toBeNull();
+  });
+
+  it('throws on non-ok response', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+    });
+
+    await expect(fetchWeather()).rejects.toThrow('Weather API error: 502');
+  });
+});


### PR DESCRIPTION
## Summary

Implements **#11 (Rain Warning)** and **#12 (Route Stats)** as a bundled feature PR.

### Issue #11 — Rain Warning
- **Azure Function proxy** (\pi/src/functions/weather.ts\): Proxies Open-Meteo API for A Coruña, 10-min server-side cache, graceful fallback on upstream failure
- **Weather service** (\src/services/weather.ts\): \etchWeather()\ returns max precipitation probability and estimated minutes until rain
- **useWeather hook** (\src/hooks/useWeather.ts\): Polls every 10 minutes, graceful degradation on error
- **RainWarning component** (\src/components/shared/RainWarning.tsx\): Amber banner when precipitation >60%, shows estimated time, dismissible
- ⚠️ Does **NOT** affect route scoring (per Morpheus design decision)

### Issue #12 — Route Stats
- **Stats calculator** (\src/services/routeStats.ts\): \calculateCalories()\ (~30 kcal/km bike, ~4 kcal/km walk), \calculateCO2Saved()\ (~0.21 kg/km vs car), format helpers
- **RouteStats component** (\src/components/RoutePanel/RouteStats.tsx\): Compact per-route stats (🚶 walk · 🚲 bike · 🔥 kcal · 🌱 CO₂)
- Integrated into RoutePanel below segment breakdown

### Tests (28 new)
- Weather service: API mocking, threshold logic, error handling (5 tests)
- Route stats: calorie/CO₂ calculations, formatters, integration (16 tests)
- Rain banner: threshold, dismissal, display logic (7 tests)

### Files Changed
| File | Description |
|------|-------------|
| \pi/src/functions/weather.ts\ | Azure Function weather proxy |
| \src/services/weather.ts\ | Frontend weather service |
| \src/hooks/useWeather.ts\ | Weather polling hook |
| \src/components/shared/RainWarning.tsx\ | Rain warning banner |
| \src/services/routeStats.ts\ | Stats calculator |
| \src/components/RoutePanel/RouteStats.tsx\ | Stats display component |
| \src/components/RoutePanel/RoutePanel.tsx\ | RouteStats integration |
| \src/App.tsx\ | RainWarning + useWeather integration |

Closes #11, closes #12