### PR TITLE
feat: FIT/EFIT/BOOST bike type filtering

### DIFF
--- a/src/components/Map/MapView.tsx
+++ b/src/components/Map/MapView.tsx
@@ -1,6 +1,7 @@
 import { MapContainer, TileLayer, ZoomControl } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import type { StationData, LatLng, MultiModalRoute } from '../../types/index.ts';
+import type { BikeType } from '../../services/bikeTypeFilter.ts';
 import StationMarkers from './StationMarkers.tsx';
 import LiveIndicator from './LiveIndicator.tsx';
 import LocationPicker from './LocationPicker.tsx';
@@ -20,6 +21,7 @@ interface MapViewProps {
   onSetOrigin: (point: LatLng) => void;
   onSetDestination: (point: LatLng) => void;
   onClearRoute: () => void;
+  preferredBikeType?: BikeType;
 }
 
 export default function MapView({
@@ -33,6 +35,7 @@ export default function MapView({
   onSetOrigin,
   onSetDestination,
   onClearRoute,
+  preferredBikeType = 'any',
 }: MapViewProps) {
   return (
     <div className="relative h-full w-full">
@@ -52,6 +55,7 @@ export default function MapView({
           stations={stations}
           selectedStationId={selectedStationId}
           onStationSelect={onStationSelect}
+          preferredBikeType={preferredBikeType}
         />
         <LocationPicker
           origin={origin}

--- a/src/components/Map/StationMarkers.tsx
+++ b/src/components/Map/StationMarkers.tsx
@@ -1,5 +1,6 @@
 import { CircleMarker } from 'react-leaflet';
 import type { StationData } from '../../types/index.ts';
+import type { BikeType } from '../../services/bikeTypeFilter.ts';
 import { getMarkerColor } from '../../utils/stationColors.ts';
 import StationPopup from './StationPopup.tsx';
 
@@ -7,12 +8,14 @@ interface StationMarkersProps {
   stations: StationData[];
   selectedStationId?: string | null;
   onStationSelect?: (station: StationData) => void;
+  preferredBikeType?: BikeType;
 }
 
 export default function StationMarkers({
   stations,
   selectedStationId,
   onStationSelect,
+  preferredBikeType = 'any',
 }: StationMarkersProps) {
   return (
     <>
@@ -33,7 +36,7 @@ export default function StationMarkers({
               click: () => onStationSelect?.(station),
             }}
           >
-            <StationPopup station={station} />
+            <StationPopup station={station} preferredBikeType={preferredBikeType} />
           </CircleMarker>
         );
       })}

--- a/src/components/Map/StationPopup.tsx
+++ b/src/components/Map/StationPopup.tsx
@@ -1,8 +1,10 @@
 import { Popup } from 'react-leaflet';
 import type { StationData } from '../../types/index.ts';
+import type { BikeType } from '../../services/bikeTypeFilter.ts';
 
 interface StationPopupProps {
   station: StationData;
+  preferredBikeType?: BikeType;
 }
 
 function formatLastReported(timestamp: number): string {
@@ -12,11 +14,13 @@ function formatLastReported(timestamp: number): string {
   return Math.floor(seconds / 3600) + 'h ago';
 }
 
-export default function StationPopup({ station }: StationPopupProps) {
-  const fitCount =
-    station.vehicle_types_available.find((v) => v.vehicle_type_id === 'FIT')?.count ?? 0;
-  const efitCount =
-    station.vehicle_types_available.find((v) => v.vehicle_type_id === 'EFIT')?.count ?? 0;
+const TYPE_LABELS: Record<string, { icon: string; label: string }> = {
+  FIT: { icon: '🔧', label: 'FIT' },
+  EFIT: { icon: '⚡', label: 'EFIT' },
+  BOOST: { icon: '🚀', label: 'BOOST' },
+};
+
+export default function StationPopup({ station, preferredBikeType = 'any' }: StationPopupProps) {
   const hasVehicleTypes = station.vehicle_types_available.length > 0;
 
   return (
@@ -40,10 +44,26 @@ export default function StationPopup({ station }: StationPopupProps) {
           </div>
 
           {hasVehicleTypes && (
-            <div className="pt-1 border-t border-gray-200 text-gray-500">
-              {fitCount > 0 && <span>{fitCount} FIT</span>}
-              {fitCount > 0 && efitCount > 0 && <span>, </span>}
-              {efitCount > 0 && <span>{efitCount} EFIT</span>}
+            <div className="pt-1 border-t border-gray-200 space-y-0.5">
+              {station.vehicle_types_available.map((vt) => {
+                const meta = TYPE_LABELS[vt.vehicle_type_id];
+                if (!meta) return null;
+                const isPreferred =
+                  preferredBikeType !== 'any' && vt.vehicle_type_id === preferredBikeType;
+                return (
+                  <div
+                    key={vt.vehicle_type_id}
+                    className={`flex justify-between items-center ${
+                      isPreferred ? 'font-semibold text-blue-700' : 'text-gray-500'
+                    }`}
+                  >
+                    <span>
+                      {meta.icon} {meta.label}
+                    </span>
+                    <span>{vt.count}</span>
+                  </div>
+                );
+              })}
             </div>
           )}
 

--- a/src/components/StationPanel/StationPanel.tsx
+++ b/src/components/StationPanel/StationPanel.tsx
@@ -1,4 +1,5 @@
 import type { StationData } from '../../types/index.ts';
+import type { BikeType } from '../../services/bikeTypeFilter.ts';
 import { getAvailabilityLevel } from '../../utils/stationColors.ts';
 import { colors } from '../../styles/tokens.ts';
 
@@ -8,6 +9,7 @@ interface StationPanelProps {
   error: string | null;
   lastUpdated: Date | null;
   onClose?: () => void;
+  preferredBikeType?: BikeType;
 }
 
 const levelLabels: Record<string, string> = {
@@ -31,6 +33,7 @@ export default function StationPanel({
   error,
   lastUpdated,
   onClose,
+  preferredBikeType = 'any',
 }: StationPanelProps) {
   if (error) {
     return (
@@ -66,10 +69,6 @@ export default function StationPanel({
 
   const level = getAvailabilityLevel(station);
   const statusColor = colors.availability[level];
-  const fitCount =
-    station.vehicle_types_available.find((v) => v.vehicle_type_id === 'FIT')?.count ?? 0;
-  const efitCount =
-    station.vehicle_types_available.find((v) => v.vehicle_type_id === 'EFIT')?.count ?? 0;
   const hasVehicleTypes = station.vehicle_types_available.length > 0;
 
   return (
@@ -125,10 +124,29 @@ export default function StationPanel({
 
         {/* Vehicle types */}
         {hasVehicleTypes && (
-          <div className="text-xs text-gray-500">
-            {fitCount > 0 && <span>{fitCount} FIT</span>}
-            {fitCount > 0 && efitCount > 0 && <span> · </span>}
-            {efitCount > 0 && <span>{efitCount} EFIT</span>}
+          <div className="grid grid-cols-3 gap-2 text-xs" data-testid="vehicle-type-breakdown">
+            {station.vehicle_types_available.map((vt) => {
+              const isPreferred =
+                preferredBikeType !== 'any' && vt.vehicle_type_id === preferredBikeType;
+              const icons: Record<string, string> = { FIT: '🔧', EFIT: '⚡', BOOST: '🚀' };
+              const icon = icons[vt.vehicle_type_id] ?? '🚲';
+              return (
+                <div
+                  key={vt.vehicle_type_id}
+                  className={`flex flex-col items-center rounded-lg p-2 ${
+                    isPreferred
+                      ? 'bg-blue-50 ring-2 ring-blue-500'
+                      : 'bg-gray-50'
+                  }`}
+                >
+                  <span className="text-base">{icon}</span>
+                  <span className={`font-semibold ${isPreferred ? 'text-blue-700' : 'text-gray-800'}`}>
+                    {vt.count}
+                  </span>
+                  <span className="text-gray-500">{vt.vehicle_type_id}</span>
+                </div>
+              );
+            })}
           </div>
         )}
 

--- a/src/components/shared/BikeTypeSelector.tsx
+++ b/src/components/shared/BikeTypeSelector.tsx
@@ -1,0 +1,49 @@
+import type { BikeType } from '../../services/bikeTypeFilter.ts';
+
+interface BikeTypeSelectorProps {
+  selectedType: BikeType;
+  onTypeChange: (type: BikeType) => void;
+}
+
+const BIKE_TYPE_OPTIONS: { value: BikeType; label: string; icon: string }[] = [
+  { value: 'any', label: 'Todas', icon: '🚲' },
+  { value: 'FIT', label: 'Mecánica', icon: '🔧' },
+  { value: 'EFIT', label: 'Eléctrica', icon: '⚡' },
+  { value: 'BOOST', label: 'Boost', icon: '🚀' },
+];
+
+export default function BikeTypeSelector({ selectedType, onTypeChange }: BikeTypeSelectorProps) {
+  return (
+    <div
+      className="flex gap-1 bg-white/90 backdrop-blur rounded-lg shadow-md p-1"
+      role="radiogroup"
+      aria-label="Tipo de bicicleta"
+      data-testid="bike-type-selector"
+    >
+      {BIKE_TYPE_OPTIONS.map(({ value, label, icon }) => {
+        const isSelected = selectedType === value;
+        return (
+          <button
+            key={value}
+            role="radio"
+            aria-checked={isSelected}
+            onClick={() => onTypeChange(value)}
+            className={`
+              flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-medium
+              transition-all cursor-pointer
+              ${
+                isSelected
+                  ? 'bg-blue-600 text-white shadow-sm'
+                  : 'text-gray-600 hover:bg-gray-100'
+              }
+            `}
+            data-testid={`bike-type-${value}`}
+          >
+            <span>{icon}</span>
+            <span>{label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/hooks/useRoutes.ts
+++ b/src/hooks/useRoutes.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import type { LatLng, MultiModalRoute, WalkingRoute } from '../types/index.ts';
 import type { StationData } from '../types/gbfs.ts';
+import type { BikeType } from '../services/bikeTypeFilter.ts';
 import { calculateMultiModalRoutes, calculateWalkingOnly } from '../services/routeEngine.ts';
 
 interface UseRoutesResult {
@@ -14,6 +15,7 @@ export function useRoutes(
   origin: LatLng | null,
   destination: LatLng | null,
   stations: StationData[],
+  bikeType: BikeType = 'any',
 ): UseRoutesResult {
   const [routes, setRoutes] = useState<MultiModalRoute[]>([]);
   const [walkingRoute, setWalkingRoute] = useState<WalkingRoute | null>(null);
@@ -35,7 +37,7 @@ export function useRoutes(
     async function fetchRoutes() {
       try {
         const [multiModal, walking] = await Promise.all([
-          calculateMultiModalRoutes(origin!, destination!, stations),
+          calculateMultiModalRoutes(origin!, destination!, stations, bikeType),
           calculateWalkingOnly(origin!, destination!),
         ]);
 
@@ -57,7 +59,7 @@ export function useRoutes(
     return () => {
       cancelled = true;
     };
-  }, [origin, destination, stations]);
+  }, [origin, destination, stations, bikeType]);
 
   return { routes, walkingRoute, loading, error };
 }

--- a/src/services/bikeTypeFilter.ts
+++ b/src/services/bikeTypeFilter.ts
@@ -1,0 +1,22 @@
+import type { StationData } from '../types/gbfs.ts';
+
+export type BikeType = 'any' | 'FIT' | 'EFIT' | 'BOOST';
+
+export function getVehicleTypeCount(station: StationData, type: BikeType): number {
+  if (type === 'any') {
+    return station.num_bikes_available;
+  }
+  return (
+    station.vehicle_types_available.find((v) => v.vehicle_type_id === type)?.count ?? 0
+  );
+}
+
+export function filterByBikeType(
+  stations: StationData[],
+  preferredType: BikeType,
+): StationData[] {
+  if (preferredType === 'any') {
+    return stations.filter((s) => s.num_bikes_available > 0);
+  }
+  return stations.filter((s) => getVehicleTypeCount(s, preferredType) > 0);
+}

--- a/src/services/routeEngine.ts
+++ b/src/services/routeEngine.ts
@@ -1,6 +1,7 @@
 import type { StationData } from '../types/gbfs.ts';
 import type { LatLng, MultiModalRoute, WalkingRoute, StationSummary } from '../types/index.ts';
 import { haversineDistance, getWalkingRoute, getCyclingRoute } from './routing.ts';
+import { type BikeType, getVehicleTypeCount } from './bikeTypeFilter.ts';
 
 const MAX_WALKING_DISTANCE_M = 1000;
 const TOP_N = 3;
@@ -21,11 +22,12 @@ export function filterPickupStations(
   stations: StationData[],
   origin: LatLng,
   maxDistance = MAX_WALKING_DISTANCE_M,
+  bikeType: BikeType = 'any',
 ): StationData[] {
   return stations
     .filter(
       (s) =>
-        s.num_bikes_available > 0 &&
+        getVehicleTypeCount(s, bikeType) > 0 &&
         s.is_renting &&
         haversineDistance(origin.lat, origin.lng, s.lat, s.lon) <= maxDistance,
     )
@@ -61,8 +63,9 @@ export async function calculateMultiModalRoutes(
   origin: LatLng,
   destination: LatLng,
   stations: StationData[],
+  bikeType: BikeType = 'any',
 ): Promise<MultiModalRoute[]> {
-  const pickups = filterPickupStations(stations, origin).slice(0, MAX_CANDIDATES);
+  const pickups = filterPickupStations(stations, origin, MAX_WALKING_DISTANCE_M, bikeType).slice(0, MAX_CANDIDATES);
   const dropoffs = filterDropoffStations(stations, destination).slice(0, MAX_CANDIDATES);
 
   if (pickups.length === 0 || dropoffs.length === 0) {

--- a/tests/unit/bikeTypeFilter.test.ts
+++ b/tests/unit/bikeTypeFilter.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from 'vitest';
+import type { StationData } from '../../src/types/gbfs';
+import { filterByBikeType, getVehicleTypeCount } from '../../src/services/bikeTypeFilter';
+
+function makeStation(
+  overrides: Partial<StationData> & { station_id: string },
+): StationData {
+  return {
+    name: 'Test Station',
+    lat: 43.362,
+    lon: -8.411,
+    capacity: 20,
+    num_bikes_available: 5,
+    num_bikes_disabled: 0,
+    num_docks_available: 10,
+    num_docks_disabled: 0,
+    is_renting: true,
+    is_returning: true,
+    is_installed: true,
+    last_reported: Date.now(),
+    vehicle_types_available: [],
+    ...overrides,
+  };
+}
+
+const stationMixed = makeStation({
+  station_id: 'mixed',
+  name: 'Mixed Station',
+  num_bikes_available: 6,
+  vehicle_types_available: [
+    { vehicle_type_id: 'FIT', count: 3 },
+    { vehicle_type_id: 'EFIT', count: 2 },
+    { vehicle_type_id: 'BOOST', count: 1 },
+  ],
+});
+
+const stationFitOnly = makeStation({
+  station_id: 'fit-only',
+  name: 'FIT Only',
+  num_bikes_available: 4,
+  vehicle_types_available: [
+    { vehicle_type_id: 'FIT', count: 4 },
+    { vehicle_type_id: 'EFIT', count: 0 },
+  ],
+});
+
+const stationEfitOnly = makeStation({
+  station_id: 'efit-only',
+  name: 'EFIT Only',
+  num_bikes_available: 2,
+  vehicle_types_available: [
+    { vehicle_type_id: 'FIT', count: 0 },
+    { vehicle_type_id: 'EFIT', count: 2 },
+  ],
+});
+
+const stationEmpty = makeStation({
+  station_id: 'empty',
+  name: 'Empty Station',
+  num_bikes_available: 0,
+  vehicle_types_available: [
+    { vehicle_type_id: 'FIT', count: 0 },
+    { vehicle_type_id: 'EFIT', count: 0 },
+  ],
+});
+
+const stationNoTypes = makeStation({
+  station_id: 'no-types',
+  name: 'No Types',
+  num_bikes_available: 3,
+  vehicle_types_available: [],
+});
+
+const allStations = [stationMixed, stationFitOnly, stationEfitOnly, stationEmpty, stationNoTypes];
+
+describe('getVehicleTypeCount', () => {
+  it('returns total bikes for "any" type', () => {
+    expect(getVehicleTypeCount(stationMixed, 'any')).toBe(6);
+  });
+
+  it('returns FIT count when type is FIT', () => {
+    expect(getVehicleTypeCount(stationMixed, 'FIT')).toBe(3);
+  });
+
+  it('returns EFIT count when type is EFIT', () => {
+    expect(getVehicleTypeCount(stationMixed, 'EFIT')).toBe(2);
+  });
+
+  it('returns BOOST count when type is BOOST', () => {
+    expect(getVehicleTypeCount(stationMixed, 'BOOST')).toBe(1);
+  });
+
+  it('returns 0 when type is not present in vehicle_types_available', () => {
+    expect(getVehicleTypeCount(stationFitOnly, 'BOOST')).toBe(0);
+  });
+
+  it('returns 0 for type with count 0', () => {
+    expect(getVehicleTypeCount(stationFitOnly, 'EFIT')).toBe(0);
+  });
+
+  it('returns 0 when vehicle_types_available is empty', () => {
+    expect(getVehicleTypeCount(stationNoTypes, 'FIT')).toBe(0);
+  });
+});
+
+describe('filterByBikeType', () => {
+  describe('with type "any"', () => {
+    it('returns all stations with bikes > 0', () => {
+      const result = filterByBikeType(allStations, 'any');
+      const ids = result.map((s) => s.station_id);
+      expect(ids).toContain('mixed');
+      expect(ids).toContain('fit-only');
+      expect(ids).toContain('efit-only');
+      expect(ids).toContain('no-types');
+      expect(ids).not.toContain('empty');
+    });
+
+    it('excludes stations with 0 bikes', () => {
+      const result = filterByBikeType(allStations, 'any');
+      expect(result.every((s) => s.num_bikes_available > 0)).toBe(true);
+    });
+  });
+
+  describe('with type "FIT"', () => {
+    it('returns only stations with FIT count > 0', () => {
+      const result = filterByBikeType(allStations, 'FIT');
+      const ids = result.map((s) => s.station_id);
+      expect(ids).toContain('mixed');
+      expect(ids).toContain('fit-only');
+      expect(ids).not.toContain('efit-only');
+      expect(ids).not.toContain('empty');
+      expect(ids).not.toContain('no-types');
+    });
+  });
+
+  describe('with type "EFIT"', () => {
+    it('returns only stations with EFIT count > 0', () => {
+      const result = filterByBikeType(allStations, 'EFIT');
+      const ids = result.map((s) => s.station_id);
+      expect(ids).toContain('mixed');
+      expect(ids).toContain('efit-only');
+      expect(ids).not.toContain('fit-only');
+      expect(ids).not.toContain('empty');
+    });
+
+    it('excludes station where EFIT count is 0', () => {
+      const result = filterByBikeType(allStations, 'EFIT');
+      expect(result.find((s) => s.station_id === 'fit-only')).toBeUndefined();
+    });
+  });
+
+  describe('with type "BOOST"', () => {
+    it('returns only stations with BOOST count > 0', () => {
+      const result = filterByBikeType(allStations, 'BOOST');
+      const ids = result.map((s) => s.station_id);
+      expect(ids).toContain('mixed');
+      expect(ids).toHaveLength(1);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty array when no stations match', () => {
+      const result = filterByBikeType([stationEmpty], 'EFIT');
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array for empty input', () => {
+      const result = filterByBikeType([], 'any');
+      expect(result).toEqual([]);
+    });
+
+    it('handles stations with no vehicle_types_available', () => {
+      const result = filterByBikeType([stationNoTypes], 'EFIT');
+      expect(result).toEqual([]);
+    });
+
+    it('handles stations with no vehicle_types_available for "any"', () => {
+      const result = filterByBikeType([stationNoTypes], 'any');
+      expect(result).toHaveLength(1);
+    });
+  });
+});

--- a/tests/unit/map.test.tsx
+++ b/tests/unit/map.test.tsx
@@ -140,7 +140,10 @@ describe('StationPopup', () => {
       ],
     });
     render(<StationPopup station={station} />);
-    expect(screen.getByText('6 FIT')).toBeInTheDocument();
-    expect(screen.getByText('2 EFIT')).toBeInTheDocument();
+    // Each type renders as: icon + label (e.g. "🔧 FIT") and count separately
+    expect(screen.getByText('🔧 FIT')).toBeInTheDocument();
+    expect(screen.getByText('⚡ EFIT')).toBeInTheDocument();
+    expect(screen.getByText('6')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
Closes #10

Adds bike type filtering so users can filter stations by vehicle type (FIT mechanical, EFIT electric, BOOST).

## Changes

### New files
- **\src/services/bikeTypeFilter.ts\** — \ilterByBikeType()\ and \getVehicleTypeCount()\ filter logic
- **\src/components/shared/BikeTypeSelector.tsx\** — Toggle UI with Todas/Mecánica/Eléctrica/Boost options
- **\	ests/unit/bikeTypeFilter.test.ts\** — 17 tests covering filter logic and edge cases

### Modified files
- **\src/App.tsx\** — Added bikeType state, BikeTypeSelector in header, filtered stations to map
- **\src/services/routeEngine.ts\** — \ilterPickupStations\ and \calculateMultiModalRoutes\ now accept bikeType parameter
- **\src/hooks/useRoutes.ts\** — Passes bikeType through to route engine
- **\src/components/Map/MapView.tsx\** — Accepts and passes preferredBikeType
- **\src/components/Map/StationMarkers.tsx\** — Passes preferredBikeType to popups
- **\src/components/Map/StationPopup.tsx\** — Shows FIT/EFIT/BOOST breakdown with icons, highlights preferred type
- **\src/components/StationPanel/StationPanel.tsx\** — Grid-based vehicle type breakdown with ring highlight
- **\	ests/unit/map.test.tsx\** — Updated popup test for new format

## Testing
- All 80 tests pass (17 new + 63 existing)
- Backward compatible: all parameters default to 'any' (no filter)
