### PR TITLE
feat: #8 confidence score for route availability

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,6 +72,7 @@ function App() {
           <RoutePanel
             routes={routes}
             walkingRoute={walkingRoute}
+            stations={stations}
             loading={routeLoading}
             error={routeError}
             selectedIndex={selectedRouteIndex}

--- a/src/components/Map/StationPopup.tsx
+++ b/src/components/Map/StationPopup.tsx
@@ -1,6 +1,11 @@
-import { Popup } from 'react-leaflet';
+﻿import { Popup } from 'react-leaflet';
 import type { StationData } from '../../types/index.ts';
 import type { BikeType } from '../../services/bikeTypeFilter.ts';
+import ConfidenceBadge from '../shared/ConfidenceBadge.tsx';
+import {
+  calculatePickupConfidence,
+  calculateDropoffConfidence,
+} from '../../services/confidenceScore.ts';
 
 interface StationPopupProps {
   station: StationData;
@@ -23,23 +28,28 @@ const TYPE_LABELS: Record<string, { icon: string; label: string }> = {
 export default function StationPopup({ station, preferredBikeType = 'any' }: StationPopupProps) {
   const hasVehicleTypes = station.vehicle_types_available.length > 0;
 
+  const pickupConf = calculatePickupConfidence(station, 0);
+  const dropoffConf = calculateDropoffConfidence(station, 0);
+
   return (
     <Popup>
       <div className="min-w-[180px]" data-testid="station-popup">
         <h3 className="font-semibold text-sm mb-2 text-gray-900">{station.name}</h3>
 
         <div className="text-xs space-y-1">
-          <div className="flex justify-between">
+          <div className="flex justify-between items-center">
             <span className="text-gray-600">Bikes</span>
-            <span className="font-medium">
-              {station.num_bikes_available}/{station.capacity} bikes
+            <span className="flex items-center gap-1 font-medium">
+              {station.num_bikes_available}/{station.capacity}
+              <ConfidenceBadge confidence={pickupConf} compact />
             </span>
           </div>
 
-          <div className="flex justify-between">
+          <div className="flex justify-between items-center">
             <span className="text-gray-600">Docks</span>
-            <span className="font-medium">
-              {station.num_docks_available}/{station.capacity} docks
+            <span className="flex items-center gap-1 font-medium">
+              {station.num_docks_available}/{station.capacity}
+              <ConfidenceBadge confidence={dropoffConf} compact />
             </span>
           </div>
 

--- a/src/components/RoutePanel/RoutePanel.tsx
+++ b/src/components/RoutePanel/RoutePanel.tsx
@@ -1,9 +1,17 @@
-import type { MultiModalRoute, WalkingRoute } from '../../types/index.ts';
+import type { MultiModalRoute, WalkingRoute, StationData } from '../../types/index.ts';
 import RouteStats from './RouteStats.tsx';
+import ConfidenceBadge from '../shared/ConfidenceBadge.tsx';
+import {
+  calculatePickupConfidence,
+  calculateDropoffConfidence,
+  routeConfidence,
+} from '../../services/confidenceScore.ts';
+import type { ConfidenceScore } from '../../services/confidenceScore.ts';
 
 interface RoutePanelProps {
   routes: MultiModalRoute[];
   walkingRoute: WalkingRoute | null;
+  stations: StationData[];
   loading: boolean;
   error: string | null;
   selectedIndex: number;
@@ -24,12 +32,14 @@ function formatDistance(meters: number): string {
 function RouteCard({
   route,
   walkingRoute,
+  confidence,
   index,
   isSelected,
   onSelect,
 }: {
   route: MultiModalRoute;
   walkingRoute: WalkingRoute | null;
+  confidence: ConfidenceScore | null;
   index: number;
   isSelected: boolean;
   onSelect: () => void;
@@ -48,18 +58,21 @@ function RouteCard({
       }`}
     >
       <div className="flex items-center justify-between mb-2">
-        <span className="text-xs font-medium text-gray-500">Ruta {index + 1}</span>
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-medium text-gray-500">Ruta {index + 1}</span>
+          {confidence && <ConfidenceBadge confidence={confidence} />}
+        </div>
         <span className="text-lg font-bold text-gray-900">{formatTime(route.total_time_seconds)}</span>
       </div>
 
       <div className="flex gap-3 text-xs text-gray-600 mb-2">
-        <span>🚶 {formatTime(route.walk_time_seconds)} ({formatDistance(route.walk_distance_meters)})</span>
-        <span>🚲 {formatTime(route.bike_time_seconds)} ({formatDistance(route.bike_distance_meters)})</span>
+        <span>{formatTime(route.walk_time_seconds)} ({formatDistance(route.walk_distance_meters)})</span>
+        <span>{formatTime(route.bike_time_seconds)} ({formatDistance(route.bike_distance_meters)})</span>
       </div>
 
       <div className="text-xs text-gray-500">
-        <div>📍 Recoger: {route.pickup_station.name}</div>
-        <div>🅿️ Dejar: {route.dropoff_station.name}</div>
+        <div>Recoger: {route.pickup_station.name}</div>
+        <div>Dejar: {route.dropoff_station.name}</div>
       </div>
 
       <RouteStats route={route} />
@@ -71,25 +84,54 @@ function RouteCard({
             : 'bg-amber-100 text-amber-700'
         }`}>
           {timeSaved > 0
-            ? `🚲 Bici: ${bikeMinutes} min | 🚶 Andando: ${walkMinutes} min | ⚡ Ahorras ${timeSaved} min`
-            : `🚶 Andando es más rápido (${walkMinutes} min vs ${bikeMinutes} min en bici)`}
+            ? `Bici: ${bikeMinutes} min | Andando: ${walkMinutes} min | Ahorras ${timeSaved} min`
+            : `Andando es mas rapido (${walkMinutes} min vs ${bikeMinutes} min en bici)`}
         </div>
       )}
     </button>
   );
 }
 
+function getRouteConfidence(
+  route: MultiModalRoute,
+  stations: StationData[],
+): ConfidenceScore | null {
+  const pickup = stations.find((s) => s.station_id === route.pickup_station.station_id);
+  const dropoff = stations.find((s) => s.station_id === route.dropoff_station.station_id);
+  if (!pickup || !dropoff) return null;
+  const walkToPickupMin = route.walk_to_pickup.duration_seconds / 60;
+  const bikeToDropoffMin = route.bike_segment.duration_seconds / 60;
+  const pickupConf = calculatePickupConfidence(pickup, walkToPickupMin);
+  const dropoffConf = calculateDropoffConfidence(dropoff, bikeToDropoffMin);
+  return routeConfidence(pickupConf, dropoffConf);
+}
+
+const LEVEL_PRIORITY: Record<string, number> = { high: 0, medium: 1, low: 2 };
+
 export default function RoutePanel({
   routes,
   walkingRoute,
+  stations,
   loading,
   error,
   selectedIndex,
   onSelectRoute,
 }: RoutePanelProps) {
+  const routesWithConfidence = routes.map((route) => ({
+    route,
+    confidence: getRouteConfidence(route, stations),
+  }));
+
+  routesWithConfidence.sort((a, b) => {
+    const aPri = a.confidence ? LEVEL_PRIORITY[a.confidence.level] ?? 2 : 2;
+    const bPri = b.confidence ? LEVEL_PRIORITY[b.confidence.level] ?? 2 : 2;
+    if (aPri !== bPri) return aPri - bPri;
+    return a.route.total_time_seconds - b.route.total_time_seconds;
+  });
+
   return (
     <div className="p-4 space-y-3">
-      <h2 className="text-lg font-semibold">🗺️ Rutas</h2>
+      <h2 className="text-lg font-semibold">Rutas</h2>
 
       {loading && (
         <div className="flex items-center gap-2 text-sm text-gray-500">
@@ -100,21 +142,22 @@ export default function RoutePanel({
 
       {error && (
         <div className="text-sm text-red-600 bg-red-50 p-2 rounded">
-          ⚠️ {error}
+          {error}
         </div>
       )}
 
-      {!loading && !error && routes.length === 0 && (
+      {!loading && !error && routesWithConfidence.length === 0 && (
         <p className="text-sm text-gray-500">
           Haz clic en el mapa para seleccionar origen y destino.
         </p>
       )}
 
-      {routes.map((route, i) => (
+      {routesWithConfidence.map(({ route, confidence }, i) => (
         <RouteCard
           key={`${route.pickup_station.station_id}-${route.dropoff_station.station_id}`}
           route={route}
           walkingRoute={walkingRoute}
+          confidence={confidence}
           index={i}
           isSelected={i === selectedIndex}
           onSelect={() => onSelectRoute(i)}
@@ -123,7 +166,7 @@ export default function RoutePanel({
 
       {walkingRoute && !loading && (
         <div className="text-xs text-gray-500 border-t pt-2 mt-2">
-          🚶 Ruta directa andando: {formatTime(walkingRoute.total_time_seconds)} ({formatDistance(walkingRoute.total_distance_meters)})
+          Ruta directa andando: {formatTime(walkingRoute.total_time_seconds)} ({formatDistance(walkingRoute.total_distance_meters)})
         </div>
       )}
     </div>

--- a/src/components/shared/ConfidenceBadge.tsx
+++ b/src/components/shared/ConfidenceBadge.tsx
@@ -1,0 +1,44 @@
+﻿import { useState } from 'react';
+import type { ConfidenceScore, ConfidenceLevel } from '../../services/confidenceScore.ts';
+
+interface ConfidenceBadgeProps {
+  confidence: ConfidenceScore;
+  compact?: boolean;
+}
+
+const levelConfig: Record<ConfidenceLevel, { emoji: string; label: string; classes: string }> = {
+  high: { emoji: '\u{1F7E2}', label: 'Alta', classes: 'bg-green-100 text-green-800' },
+  medium: { emoji: '\u{1F7E1}', label: 'Media', classes: 'bg-amber-100 text-amber-800' },
+  low: { emoji: '\u{1F534}', label: 'Baja', classes: 'bg-red-100 text-red-800' },
+};
+
+export default function ConfidenceBadge({ confidence, compact = false }: ConfidenceBadgeProps) {
+  const [showTooltip, setShowTooltip] = useState(false);
+  const config = levelConfig[confidence.level];
+
+  return (
+    <span
+      className="relative inline-flex items-center"
+      onMouseEnter={() => setShowTooltip(true)}
+      onMouseLeave={() => setShowTooltip(false)}
+      data-testid="confidence-badge"
+      data-level={confidence.level}
+    >
+      <span
+        className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${config.classes}`}
+      >
+        <span>{config.emoji}</span>
+        {!compact && <span>{config.label}</span>}
+      </span>
+
+      {showTooltip && (
+        <span
+          className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 text-xs text-white bg-gray-800 rounded shadow-lg whitespace-nowrap z-50"
+          data-testid="confidence-tooltip"
+        >
+          {confidence.reason}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/src/services/confidenceScore.ts
+++ b/src/services/confidenceScore.ts
@@ -1,0 +1,122 @@
+﻿import type { StationData } from '../types/gbfs.ts';
+
+export type ConfidenceLevel = 'high' | 'medium' | 'low';
+
+export interface ConfidenceScore {
+  level: ConfidenceLevel;
+  score: number;
+  reason: string;
+}
+
+const LEVEL_ORDER: ConfidenceLevel[] = ['high', 'medium', 'low'];
+
+function downgrade(level: ConfidenceLevel): ConfidenceLevel {
+  const idx = LEVEL_ORDER.indexOf(level);
+  return LEVEL_ORDER[Math.min(idx + 1, LEVEL_ORDER.length - 1)]!;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function calculatePickupConfidence(
+  station: StationData,
+  walkTimeMinutes: number,
+): ConfidenceScore {
+  if (!station.is_renting) {
+    return { level: 'low', score: 0, reason: 'La estacion no esta alquilando' };
+  }
+  const capacity = station.capacity;
+  if (capacity === 0) {
+    return { level: 'low', score: 0, reason: 'La estacion no tiene capacidad' };
+  }
+  const bikes = station.num_bikes_available;
+  const ratio = bikes / capacity;
+  let level: ConfidenceLevel;
+  let score: number;
+  if (ratio > 0.5) {
+    level = 'high';
+    score = clamp(70 + ratio * 30, 70, 100);
+  } else if (ratio >= 0.25) {
+    level = 'medium';
+    score = clamp(30 + ratio * 80, 30, 69);
+  } else {
+    level = 'low';
+    score = clamp(ratio * 120, 0, 29);
+  }
+  if (walkTimeMinutes > 5 && bikes <= 2) {
+    level = downgrade(level);
+    score = clamp(score - 20, 0, 100);
+  }
+  const reason = buildPickupReason(bikes, walkTimeMinutes, level);
+  return { level, score: Math.round(score), reason };
+}
+
+export function calculateDropoffConfidence(
+  station: StationData,
+  walkTimeMinutes: number,
+): ConfidenceScore {
+  if (!station.is_returning) {
+    return { level: 'low', score: 0, reason: 'La estacion no acepta devoluciones' };
+  }
+  const capacity = station.capacity;
+  if (capacity === 0) {
+    return { level: 'low', score: 0, reason: 'La estacion no tiene capacidad' };
+  }
+  const docks = station.num_docks_available;
+  const ratio = docks / capacity;
+  let level: ConfidenceLevel;
+  let score: number;
+  if (ratio > 0.5) {
+    level = 'high';
+    score = clamp(70 + ratio * 30, 70, 100);
+  } else if (ratio >= 0.25) {
+    level = 'medium';
+    score = clamp(30 + ratio * 80, 30, 69);
+  } else {
+    level = 'low';
+    score = clamp(ratio * 120, 0, 29);
+  }
+  if (walkTimeMinutes > 5 && docks <= 2) {
+    level = downgrade(level);
+    score = clamp(score - 20, 0, 100);
+  }
+  const reason = buildDropoffReason(docks, walkTimeMinutes, level);
+  return { level, score: Math.round(score), reason };
+}
+
+export function routeConfidence(
+  pickup: ConfidenceScore,
+  dropoff: ConfidenceScore,
+): ConfidenceScore {
+  const pickupIdx = LEVEL_ORDER.indexOf(pickup.level);
+  const dropoffIdx = LEVEL_ORDER.indexOf(dropoff.level);
+  if (pickupIdx >= dropoffIdx) {
+    return { level: pickup.level, score: Math.min(pickup.score, dropoff.score), reason: pickup.reason };
+  }
+  return { level: dropoff.level, score: Math.min(pickup.score, dropoff.score), reason: dropoff.reason };
+}
+
+function buildPickupReason(bikes: number, walkMin: number, level: ConfidenceLevel): string {
+  if (level === 'high') return bikes + ' bicis disponibles';
+  if (level === 'medium') {
+    return walkMin > 5
+      ? 'Solo ' + bikes + ' bicis y estas a ' + Math.round(walkMin) + ' min andando'
+      : bikes + ' bicis disponibles';
+  }
+  return walkMin > 5
+    ? 'Solo ' + bikes + ' bicis disponibles y estas a ' + Math.round(walkMin) + ' min andando'
+    : 'Solo ' + bikes + ' bicis disponibles';
+}
+
+function buildDropoffReason(docks: number, walkMin: number, level: ConfidenceLevel): string {
+  if (level === 'high') return docks + ' huecos disponibles';
+  if (level === 'medium') {
+    return walkMin > 5
+      ? 'Solo ' + docks + ' huecos y estas a ' + Math.round(walkMin) + ' min'
+      : docks + ' huecos disponibles';
+  }
+  return walkMin > 5
+    ? 'Solo ' + docks + ' huecos disponibles y estas a ' + Math.round(walkMin) + ' min'
+    : 'Solo ' + docks + ' huecos disponibles';
+}

--- a/tests/unit/confidenceScore.test.ts
+++ b/tests/unit/confidenceScore.test.ts
@@ -1,0 +1,144 @@
+﻿import { describe, it, expect } from 'vitest';
+import {
+  calculatePickupConfidence,
+  calculateDropoffConfidence,
+  routeConfidence,
+} from '../../src/services/confidenceScore.ts';
+import type { StationData } from '../../src/types/gbfs.ts';
+
+function makeStation(overrides: Partial<StationData> = {}): StationData {
+  return {
+    station_id: 'test-1',
+    name: 'Test Station',
+    lat: 43.37,
+    lon: -8.4,
+    capacity: 20,
+    num_bikes_available: 10,
+    num_bikes_disabled: 0,
+    num_docks_available: 10,
+    num_docks_disabled: 0,
+    is_renting: true,
+    is_returning: true,
+    is_installed: true,
+    last_reported: Date.now() / 1000,
+    vehicle_types_available: [],
+    ...overrides,
+  };
+}
+
+describe('calculatePickupConfidence', () => {
+  it('returns high when ratio > 0.5', () => {
+    const s = makeStation({ num_bikes_available: 15, capacity: 20 });
+    const r = calculatePickupConfidence(s, 3);
+    expect(r.level).toBe('high');
+    expect(r.score).toBeGreaterThanOrEqual(70);
+    expect(r.score).toBeLessThanOrEqual(100);
+  });
+  it('returns medium when ratio 0.25-0.5', () => {
+    const s = makeStation({ num_bikes_available: 8, capacity: 20 });
+    const r = calculatePickupConfidence(s, 3);
+    expect(r.level).toBe('medium');
+    expect(r.score).toBeGreaterThanOrEqual(30);
+    expect(r.score).toBeLessThan(70);
+  });
+  it('returns low when ratio < 0.25', () => {
+    const s = makeStation({ num_bikes_available: 2, capacity: 20 });
+    const r = calculatePickupConfidence(s, 3);
+    expect(r.level).toBe('low');
+    expect(r.score).toBeLessThan(30);
+  });
+  it('returns low/0 when not renting', () => {
+    const s = makeStation({ is_renting: false, num_bikes_available: 15 });
+    const r = calculatePickupConfidence(s, 1);
+    expect(r.level).toBe('low');
+    expect(r.score).toBe(0);
+  });
+  it('returns low/0 when zero capacity', () => {
+    const s = makeStation({ capacity: 0 });
+    const r = calculatePickupConfidence(s, 1);
+    expect(r.level).toBe('low');
+    expect(r.score).toBe(0);
+  });
+  it('downgrades when walkTime > 5 and bikes <= 2', () => {
+    const s = makeStation({ num_bikes_available: 2, capacity: 8 });
+    const short_ = calculatePickupConfidence(s, 3);
+    const long_ = calculatePickupConfidence(s, 8);
+    expect(short_.level).toBe('medium');
+    expect(long_.level).toBe('low');
+    expect(long_.score).toBeLessThan(short_.score);
+  });
+  it('does NOT downgrade when bikes > 2', () => {
+    const s = makeStation({ num_bikes_available: 6, capacity: 20 });
+    expect(calculatePickupConfidence(s, 3).level).toBe('medium');
+    expect(calculatePickupConfidence(s, 8).level).toBe('medium');
+  });
+  it('handles 0 bikes as low', () => {
+    const s = makeStation({ num_bikes_available: 0, capacity: 20 });
+    const r = calculatePickupConfidence(s, 1);
+    expect(r.level).toBe('low');
+    expect(r.score).toBe(0);
+  });
+  it('handles full station as high', () => {
+    const s = makeStation({ num_bikes_available: 20, capacity: 20 });
+    const r = calculatePickupConfidence(s, 1);
+    expect(r.level).toBe('high');
+    expect(r.score).toBeGreaterThanOrEqual(70);
+  });
+});
+
+describe('calculateDropoffConfidence', () => {
+  it('returns high when ratio > 0.5', () => {
+    const s = makeStation({ num_docks_available: 15, capacity: 20 });
+    expect(calculateDropoffConfidence(s, 3).level).toBe('high');
+  });
+  it('returns medium when ratio 0.25-0.5', () => {
+    const s = makeStation({ num_docks_available: 8, capacity: 20 });
+    expect(calculateDropoffConfidence(s, 3).level).toBe('medium');
+  });
+  it('returns low when ratio < 0.25', () => {
+    const s = makeStation({ num_docks_available: 2, capacity: 20 });
+    expect(calculateDropoffConfidence(s, 3).level).toBe('low');
+  });
+  it('returns low/0 when not returning', () => {
+    const s = makeStation({ is_returning: false, num_docks_available: 15 });
+    const r = calculateDropoffConfidence(s, 1);
+    expect(r.level).toBe('low');
+    expect(r.score).toBe(0);
+  });
+  it('downgrades when walkTime > 5 and docks <= 2', () => {
+    const s = makeStation({ num_docks_available: 2, capacity: 8 });
+    expect(calculateDropoffConfidence(s, 3).level).toBe('medium');
+    expect(calculateDropoffConfidence(s, 8).level).toBe('low');
+  });
+});
+
+describe('routeConfidence', () => {
+  it('returns worst (pickup worse)', () => {
+    const p = { level: 'low' as const, score: 15, reason: 'x' };
+    const d = { level: 'high' as const, score: 90, reason: 'y' };
+    const r = routeConfidence(p, d);
+    expect(r.level).toBe('low');
+    expect(r.score).toBe(15);
+  });
+  it('returns worst (dropoff worse)', () => {
+    const p = { level: 'high' as const, score: 85, reason: 'x' };
+    const d = { level: 'medium' as const, score: 45, reason: 'y' };
+    const r = routeConfidence(p, d);
+    expect(r.level).toBe('medium');
+    expect(r.score).toBe(45);
+  });
+  it('returns high when both high', () => {
+    const p = { level: 'high' as const, score: 90, reason: 'x' };
+    const d = { level: 'high' as const, score: 85, reason: 'y' };
+    const r = routeConfidence(p, d);
+    expect(r.level).toBe('high');
+    expect(r.score).toBe(85);
+  });
+  it('returns low when both low', () => {
+    const p = { level: 'low' as const, score: 10, reason: 'x' };
+    const d = { level: 'low' as const, score: 5, reason: 'y' };
+    const r = routeConfidence(p, d);
+    expect(r.level).toBe('low');
+    expect(r.score).toBe(5);
+  });
+});

--- a/tests/unit/map.test.tsx
+++ b/tests/unit/map.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+﻿import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import type { StationData } from '../../src/types/index';
 import { getAvailabilityLevel, getMarkerColor } from '../../src/utils/stationColors';
@@ -128,8 +128,9 @@ describe('StationPopup', () => {
       capacity: 15,
     });
     render(<StationPopup station={station} />);
-    expect(screen.getByText('8/15 bikes')).toBeInTheDocument();
-    expect(screen.getByText('7/15 docks')).toBeInTheDocument();
+    expect(screen.getByText('Bikes')).toBeInTheDocument();
+    expect(screen.getByText('Docks')).toBeInTheDocument();
+    expect(screen.getAllByTestId('confidence-badge').length).toBe(2);
   });
 
   it('shows vehicle type breakdown when available', () => {


### PR DESCRIPTION
## Confidence Score for Route Availability (#8)

### What
Implements the heuristic confidence score system (🟢🟡🔴) — BiciCoruña's key differentiator vs Google Maps. Users can now see at a glance whether a bike/dock will still be available when they arrive.

### Changes
- **src/services/confidenceScore.ts** — Core algorithm: calculatePickupConfidence(), calculateDropoffConfidence(), outeConfidence() with bike/dock ratio thresholds + walk-time adjustment
- **src/components/shared/ConfidenceBadge.tsx** — Reusable badge component (Alta/Media/Baja) with hover tooltip explaining the reason
- **src/components/RoutePanel/RoutePanel.tsx** — Routes now show confidence badges, sorted by confidence first then time
- **src/components/Map/StationPopup.tsx** — Station popup shows pickup + dropoff confidence inline
- **src/App.tsx** — Passes stations to RoutePanel for confidence lookups
- **	ests/unit/confidenceScore.test.ts** — 18 unit tests covering all thresholds, edge cases, walk-time downgrades

### Algorithm
- **bikes_ratio** = bikes_available / capacity → high (>0.5), medium (0.25-0.5), low (<0.25)
- **Walk time adjustment**: if walkTime > 5min AND bikes ≤ 2 → downgrade one level
- **Route confidence** = worst of pickup + dropoff scores
- Offline station → always low/0

Closes #8