### PR TITLE
feat: #9 #14 availability prediction with enhanced weighting

### DIFF
--- a/api/src/functions/predict.ts
+++ b/api/src/functions/predict.ts
@@ -1,0 +1,243 @@
+import { app } from '@azure/functions';
+import type { HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
+import { getContainer } from '../shared/cosmos-client.js';
+import type { StationSnapshot } from './stationCollector.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type PredictionConfidence = 'high' | 'medium' | 'low' | 'none';
+
+export interface PredictionResult {
+  predicted: number | null;
+  confidence: PredictionConfidence;
+  range: [number, number] | null;
+  dataPoints: number;
+  message?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for unit testing)
+// ---------------------------------------------------------------------------
+
+/** Whether a given hour falls within morning (7-9) or evening (17-19) rush. */
+export function isRushHour(hour: number): boolean {
+  return (hour >= 7 && hour <= 9) || (hour >= 17 && hour <= 19);
+}
+
+/** Whether a day-of-week is a weekend (0 = Sunday, 6 = Saturday). */
+export function isWeekend(dayOfWeek: number): boolean {
+  return dayOfWeek === 0 || dayOfWeek === 6;
+}
+
+/** Determine confidence level from data point count. */
+export function computeConfidence(dataPoints: number): PredictionConfidence {
+  if (dataPoints <= 0) return 'none';
+  if (dataPoints < 10) return 'low';
+  if (dataPoints <= 50) return 'medium';
+  return 'high';
+}
+
+/**
+ * Compute the prediction from an array of historical bike-availability values.
+ *
+ * Algorithm:
+ *   trend_extrapolation * 0.6 + historical_mean * 0.4
+ *
+ * Enhanced (Issue #14): when 5+ distinct weeks of data are available,
+ * observations are weighted by day-of-week + hour relevance.
+ */
+export function computePrediction(
+  snapshots: Pick<StationSnapshot, 'bikesAvailable' | 'timestamp' | 'hour' | 'dayOfWeek'>[],
+  targetHour: number,
+  targetDayOfWeek: number,
+): PredictionResult {
+  if (snapshots.length === 0) {
+    return { predicted: null, confidence: 'none', range: null, dataPoints: 0, message: 'Insufficient data' };
+  }
+
+  // --- Enhanced weighting (Issue #14) ---
+  const distinctWeeks = new Set(
+    snapshots.map((s) => {
+      const d = new Date(s.timestamp);
+      const yearWeek = d.getFullYear() * 100 + Math.floor(dayOfYear(d) / 7);
+      return yearWeek;
+    }),
+  ).size;
+
+  const useEnhanced = distinctWeeks >= 5;
+  const targetIsWeekend = isWeekend(targetDayOfWeek);
+  const targetIsRush = isRushHour(targetHour);
+
+  // Assign weights
+  const weighted: { value: number; weight: number }[] = snapshots.map((s) => {
+    let weight = 1;
+    if (useEnhanced) {
+      // Day-of-week match bonus
+      if (s.dayOfWeek === targetDayOfWeek) {
+        weight += 1;
+      } else if (isWeekend(s.dayOfWeek) === targetIsWeekend) {
+        weight += 0.5;
+      }
+      // Rush-hour alignment bonus
+      if (isRushHour(s.hour) === targetIsRush) {
+        weight += 0.5;
+      }
+    }
+    return { value: s.bikesAvailable, weight };
+  });
+
+  // Weighted mean
+  const totalWeight = weighted.reduce((sum, w) => sum + w.weight, 0);
+  const historicalMean = weighted.reduce((sum, w) => sum + w.value * w.weight, 0) / totalWeight;
+
+  // Trend extrapolation: simple linear regression on chronologically sorted values
+  const sorted = [...snapshots].sort(
+    (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+  );
+  const n = sorted.length;
+  let sumX = 0, sumY = 0, sumXY = 0, sumX2 = 0;
+  for (let i = 0; i < n; i++) {
+    sumX += i;
+    sumY += sorted[i].bikesAvailable;
+    sumXY += i * sorted[i].bikesAvailable;
+    sumX2 += i * i;
+  }
+  const denominator = n * sumX2 - sumX * sumX;
+  const slope = denominator !== 0 ? (n * sumXY - sumX * sumY) / denominator : 0;
+  const intercept = (sumY - slope * sumX) / n;
+  const trendExtrapolation = Math.max(0, intercept + slope * n);
+
+  // Blend
+  const predicted = Math.round(trendExtrapolation * 0.6 + historicalMean * 0.4);
+
+  // Confidence
+  const confidence = computeConfidence(snapshots.length);
+
+  // Range (±std dev, minimum ±1)
+  const meanVal = sumY / n;
+  const variance = sorted.reduce((sum, s) => sum + (s.bikesAvailable - meanVal) ** 2, 0) / n;
+  const stdDev = Math.sqrt(variance);
+  const margin = Math.max(1, Math.round(stdDev));
+  const range: [number, number] = [Math.max(0, predicted - margin), predicted + margin];
+
+  return { predicted, confidence, range, dataPoints: snapshots.length };
+}
+
+/** Day of year helper (1-indexed). */
+function dayOfYear(date: Date): number {
+  const start = new Date(date.getFullYear(), 0, 0);
+  const diff = date.getTime() - start.getTime();
+  return Math.floor(diff / 86_400_000);
+}
+
+// ---------------------------------------------------------------------------
+// Cosmos DB query
+// ---------------------------------------------------------------------------
+
+async function queryHistoricalSnapshots(
+  stationId: string,
+  targetHour: number,
+  targetDayOfWeek: number,
+): Promise<StationSnapshot[]> {
+  const container = getContainer();
+
+  const fourteenDaysAgo = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString();
+  const hourLow = (targetHour - 1 + 24) % 24;
+  const hourHigh = (targetHour + 1) % 24;
+
+  // Handle hour wrap-around (e.g. hour 0 ± 1 → 23, 0, 1)
+  let hourClause: string;
+  if (hourLow <= hourHigh) {
+    hourClause = `c.hour >= ${hourLow} AND c.hour <= ${hourHigh}`;
+  } else {
+    hourClause = `(c.hour >= ${hourLow} OR c.hour <= ${hourHigh})`;
+  }
+
+  const querySpec = {
+    query: `SELECT * FROM c WHERE c.stationId = @stationId AND c.timestamp >= @since AND c.dayOfWeek = @dow AND ${hourClause}`,
+    parameters: [
+      { name: '@stationId', value: stationId },
+      { name: '@since', value: fourteenDaysAgo },
+      { name: '@dow', value: targetDayOfWeek },
+    ],
+  };
+
+  const { resources } = await container.items
+    .query<StationSnapshot>(querySpec)
+    .fetchAll();
+
+  return resources;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP handler
+// ---------------------------------------------------------------------------
+
+export async function predictHandler(
+  req: HttpRequest,
+  context: InvocationContext,
+): Promise<HttpResponseInit> {
+  const stationParam = req.query.get('station');
+  const horizonParam = req.query.get('horizon') ?? '30';
+
+  if (!stationParam) {
+    return {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Missing required query parameter: station' }),
+    };
+  }
+
+  const horizonMinutes = parseInt(horizonParam, 10);
+  if (isNaN(horizonMinutes) || horizonMinutes < 0) {
+    return {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Invalid horizon parameter' }),
+    };
+  }
+
+  try {
+    const target = new Date(Date.now() + horizonMinutes * 60_000);
+    const targetHour = target.getUTCHours();
+    const targetDayOfWeek = target.getUTCDay();
+
+    const snapshots = await queryHistoricalSnapshots(stationParam, targetHour, targetDayOfWeek);
+
+    context.log(
+      `Prediction for station ${stationParam}: ${snapshots.length} data points, ` +
+        `horizon=${horizonMinutes}min, targetHour=${targetHour}, dow=${targetDayOfWeek}`,
+    );
+
+    const result = computePrediction(snapshots, targetHour, targetDayOfWeek);
+
+    return {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(result),
+    };
+  } catch (err) {
+    context.error(`Prediction error: ${err}`);
+    return {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        error: 'Failed to compute prediction',
+        message: err instanceof Error ? err.message : String(err),
+      }),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Function registration
+// ---------------------------------------------------------------------------
+
+app.http('predict', {
+  methods: ['GET'],
+  authLevel: 'anonymous',
+  route: 'predict',
+  handler: predictHandler,
+});

--- a/src/components/Map/StationPopup.tsx
+++ b/src/components/Map/StationPopup.tsx
@@ -2,10 +2,12 @@
 import type { StationData } from '../../types/index.ts';
 import type { BikeType } from '../../services/bikeTypeFilter.ts';
 import ConfidenceBadge from '../shared/ConfidenceBadge.tsx';
+import PredictionBadge from '../shared/PredictionBadge.tsx';
 import {
   calculatePickupConfidence,
   calculateDropoffConfidence,
 } from '../../services/confidenceScore.ts';
+import { usePrediction } from '../../hooks/usePrediction.ts';
 
 interface StationPopupProps {
   station: StationData;
@@ -30,6 +32,7 @@ export default function StationPopup({ station, preferredBikeType = 'any' }: Sta
 
   const pickupConf = calculatePickupConfidence(station, 0);
   const dropoffConf = calculateDropoffConfidence(station, 0);
+  const { prediction, loading: predLoading } = usePrediction(station.station_id);
 
   return (
     <Popup>
@@ -79,6 +82,10 @@ export default function StationPopup({ station, preferredBikeType = 'any' }: Sta
 
           <div className="pt-1 text-gray-400">
             Updated {formatLastReported(station.last_reported)}
+          </div>
+
+          <div className="pt-1 border-t border-gray-200">
+            <PredictionBadge prediction={prediction} loading={predLoading} />
           </div>
         </div>
       </div>

--- a/src/components/shared/PredictionBadge.tsx
+++ b/src/components/shared/PredictionBadge.tsx
@@ -1,0 +1,60 @@
+import type { PredictionResult } from '../../services/prediction.ts';
+
+interface PredictionBadgeProps {
+  prediction: PredictionResult | null;
+  loading: boolean;
+  horizonMinutes?: number;
+}
+
+const confidenceColors: Record<string, string> = {
+  high: 'text-green-700 bg-green-50',
+  medium: 'text-amber-700 bg-amber-50',
+  low: 'text-red-700 bg-red-50',
+};
+
+export default function PredictionBadge({
+  prediction,
+  loading,
+  horizonMinutes = 30,
+}: PredictionBadgeProps) {
+  if (loading) {
+    return (
+      <div
+        className="text-xs text-gray-400 animate-pulse"
+        data-testid="prediction-loading"
+      >
+        Calculando predicción…
+      </div>
+    );
+  }
+
+  if (!prediction || prediction.predicted === null || prediction.confidence === 'none') {
+    return (
+      <div
+        className="text-xs text-gray-400 italic"
+        data-testid="prediction-unavailable"
+      >
+        Predicción no disponible — recopilando datos
+      </div>
+    );
+  }
+
+  const margin = prediction.range
+    ? Math.round((prediction.range[1] - prediction.range[0]) / 2)
+    : 0;
+
+  const colorClasses = confidenceColors[prediction.confidence] ?? 'text-gray-700 bg-gray-50';
+
+  return (
+    <div
+      className={`text-xs rounded px-1.5 py-0.5 ${colorClasses}`}
+      data-testid="prediction-badge"
+      data-confidence={prediction.confidence}
+    >
+      <span>
+        En {horizonMinutes} min: ~{prediction.predicted} bicis
+        {margin > 0 && ` (±${margin})`}
+      </span>
+    </div>
+  );
+}

--- a/src/hooks/usePrediction.ts
+++ b/src/hooks/usePrediction.ts
@@ -1,0 +1,43 @@
+import { useState, useEffect, useCallback } from 'react';
+import { fetchPrediction, type PredictionResult } from '../services/prediction.ts';
+
+interface UsePredictionResult {
+  prediction: PredictionResult | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export function usePrediction(
+  stationId: string | null,
+  horizonMinutes: number = 30,
+): UsePredictionResult {
+  const [prediction, setPrediction] = useState<PredictionResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!stationId) {
+      setPrediction(null);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const result = await fetchPrediction(stationId, horizonMinutes);
+      setPrediction(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setPrediction(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [stationId, horizonMinutes]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return { prediction, loading, error };
+}

--- a/src/services/prediction.ts
+++ b/src/services/prediction.ts
@@ -1,0 +1,28 @@
+export type PredictionConfidence = 'high' | 'medium' | 'low' | 'none';
+
+export interface PredictionResult {
+  predicted: number | null;
+  confidence: PredictionConfidence;
+  range: [number, number] | null;
+  dataPoints: number;
+  message?: string;
+}
+
+const PREDICT_API_URL = '/api/predict';
+
+/**
+ * Fetch availability prediction for a station from the prediction API.
+ */
+export async function fetchPrediction(
+  stationId: string,
+  horizonMinutes: number = 30,
+): Promise<PredictionResult> {
+  const url = `${PREDICT_API_URL}?station=${encodeURIComponent(stationId)}&horizon=${horizonMinutes}`;
+  const res = await fetch(url);
+
+  if (!res.ok) {
+    throw new Error(`Prediction API error: ${res.status}`);
+  }
+
+  return res.json();
+}

--- a/tests/unit/prediction.test.ts
+++ b/tests/unit/prediction.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computePrediction,
+  computeConfidence,
+  isRushHour,
+  isWeekend,
+} from '../../api/src/functions/predict';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a snapshot-like object for testing. */
+function makeSnapshot(
+  bikesAvailable: number,
+  overrides: {
+    timestamp?: string;
+    hour?: number;
+    dayOfWeek?: number;
+  } = {},
+) {
+  const ts = overrides.timestamp ?? '2026-06-10T10:00:00.000Z'; // Wednesday
+  const d = new Date(ts);
+  return {
+    bikesAvailable,
+    timestamp: ts,
+    hour: overrides.hour ?? d.getUTCHours(),
+    dayOfWeek: overrides.dayOfWeek ?? d.getUTCDay(),
+  };
+}
+
+/** Generate N snapshots spread across different weeks for enhanced mode. */
+function makeMultiWeekSnapshots(
+  values: number[],
+  opts: { hour?: number; dayOfWeek?: number } = {},
+) {
+  return values.map((v, i) => {
+    const d = new Date('2026-03-01T10:00:00.000Z');
+    d.setDate(d.getDate() + i * 7); // one per week
+    return makeSnapshot(v, {
+      timestamp: d.toISOString(),
+      hour: opts.hour ?? d.getUTCHours(),
+      dayOfWeek: opts.dayOfWeek ?? d.getUTCDay(),
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('prediction', () => {
+  // --- computeConfidence ---
+
+  describe('computeConfidence', () => {
+    it('returns "none" for 0 data points', () => {
+      expect(computeConfidence(0)).toBe('none');
+    });
+
+    it('returns "low" for < 10 data points', () => {
+      expect(computeConfidence(1)).toBe('low');
+      expect(computeConfidence(9)).toBe('low');
+    });
+
+    it('returns "medium" for 10-50 data points', () => {
+      expect(computeConfidence(10)).toBe('medium');
+      expect(computeConfidence(50)).toBe('medium');
+    });
+
+    it('returns "high" for > 50 data points', () => {
+      expect(computeConfidence(51)).toBe('high');
+      expect(computeConfidence(100)).toBe('high');
+    });
+  });
+
+  // --- isRushHour ---
+
+  describe('isRushHour', () => {
+    it('identifies morning rush hours (7-9)', () => {
+      expect(isRushHour(7)).toBe(true);
+      expect(isRushHour(8)).toBe(true);
+      expect(isRushHour(9)).toBe(true);
+    });
+
+    it('identifies evening rush hours (17-19)', () => {
+      expect(isRushHour(17)).toBe(true);
+      expect(isRushHour(18)).toBe(true);
+      expect(isRushHour(19)).toBe(true);
+    });
+
+    it('returns false for non-rush hours', () => {
+      expect(isRushHour(6)).toBe(false);
+      expect(isRushHour(10)).toBe(false);
+      expect(isRushHour(12)).toBe(false);
+      expect(isRushHour(16)).toBe(false);
+      expect(isRushHour(20)).toBe(false);
+    });
+  });
+
+  // --- isWeekend ---
+
+  describe('isWeekend', () => {
+    it('identifies Sunday (0) and Saturday (6) as weekend', () => {
+      expect(isWeekend(0)).toBe(true);
+      expect(isWeekend(6)).toBe(true);
+    });
+
+    it('identifies weekdays as non-weekend', () => {
+      for (let d = 1; d <= 5; d++) {
+        expect(isWeekend(d)).toBe(false);
+      }
+    });
+  });
+
+  // --- No data fallback ---
+
+  describe('computePrediction — no data', () => {
+    it('returns null prediction with "none" confidence when no snapshots', () => {
+      const result = computePrediction([], 10, 3);
+      expect(result.predicted).toBeNull();
+      expect(result.confidence).toBe('none');
+      expect(result.range).toBeNull();
+      expect(result.dataPoints).toBe(0);
+      expect(result.message).toBe('Insufficient data');
+    });
+  });
+
+  // --- Basic algorithm ---
+
+  describe('computePrediction — basic algorithm', () => {
+    it('predicts a value from uniform data', () => {
+      const snapshots = Array.from({ length: 20 }, () => makeSnapshot(8));
+      const result = computePrediction(snapshots, 10, 3);
+
+      expect(result.predicted).toBe(8);
+      expect(result.confidence).toBe('medium'); // 20 data points
+      expect(result.range).not.toBeNull();
+      expect(result.dataPoints).toBe(20);
+    });
+
+    it('blends trend extrapolation with historical mean', () => {
+      // Linearly increasing: 2, 4, 6, 8, 10
+      const snapshots = [2, 4, 6, 8, 10].map((v, i) => {
+        const d = new Date('2026-06-10T10:00:00.000Z');
+        d.setHours(d.getHours() + i);
+        return makeSnapshot(v, { timestamp: d.toISOString() });
+      });
+
+      const result = computePrediction(snapshots, 10, 3);
+
+      // trend extrapolation at x=5: intercept=2, slope=2, so 2+2*5=12
+      // historical mean = 6
+      // blended = 12*0.6 + 6*0.4 = 7.2 + 2.4 = 9.6 → 10
+      expect(result.predicted).toBe(10);
+    });
+
+    it('never returns a negative predicted value', () => {
+      // Decreasing trend
+      const snapshots = [10, 8, 6, 4, 2, 0].map((v, i) => {
+        const d = new Date('2026-06-10T10:00:00.000Z');
+        d.setHours(d.getHours() + i);
+        return makeSnapshot(v, { timestamp: d.toISOString() });
+      });
+
+      const result = computePrediction(snapshots, 10, 3);
+      expect(result.predicted).toBeGreaterThanOrEqual(0);
+    });
+
+    it('returns correct confidence for few data points', () => {
+      const snapshots = [makeSnapshot(5), makeSnapshot(7)];
+      const result = computePrediction(snapshots, 10, 3);
+      expect(result.confidence).toBe('low'); // 2 data points
+    });
+
+    it('returns range with at least ±1', () => {
+      // All same value → 0 std dev → margin clamps to 1
+      const snapshots = Array.from({ length: 5 }, () => makeSnapshot(10));
+      const result = computePrediction(snapshots, 10, 3);
+      expect(result.range).not.toBeNull();
+      expect(result.range![1] - result.range![0]).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  // --- Enhanced algorithm (Issue #14) ---
+
+  describe('computePrediction — enhanced weighting', () => {
+    it('activates enhanced mode with 5+ distinct weeks of data', () => {
+      // 6 snapshots across 6 different weeks
+      const snapshots = makeMultiWeekSnapshots(
+        [5, 6, 7, 8, 9, 10],
+        { hour: 10, dayOfWeek: 3 },
+      );
+
+      const result = computePrediction(snapshots, 10, 3);
+      expect(result.predicted).not.toBeNull();
+      expect(result.dataPoints).toBe(6);
+    });
+
+    it('gives higher weight to matching day-of-week data', () => {
+      // Target: Wednesday (3), hour 10
+      const wednesdaySnapshots = makeMultiWeekSnapshots(
+        [10, 10, 10, 10, 10, 10, 10],
+        { hour: 10, dayOfWeek: 3 },
+      );
+      const mondaySnapshots = makeMultiWeekSnapshots(
+        [2, 2, 2, 2, 2, 2, 2],
+        { hour: 10, dayOfWeek: 1 },
+      );
+
+      // With only Wednesday data → prediction ~10
+      const wedResult = computePrediction(wednesdaySnapshots, 10, 3);
+      expect(wedResult.predicted).toBe(10);
+
+      // Simple unweighted average would be 6. The weighted mean should
+      // pull toward the matching day-of-week (Wednesday = 10), but
+      // the 60/40 trend/mean blend moderates the effect.
+      const mixed = [...wednesdaySnapshots, ...mondaySnapshots];
+      const mixedResult = computePrediction(mixed, 10, 3);
+      expect(mixedResult.predicted).toBeGreaterThanOrEqual(6);
+      expect(mixedResult.dataPoints).toBe(14);
+    });
+
+    it('differentiates rush hour weighting', () => {
+      // Rush hour data (hour 8) vs non-rush (hour 14), target is rush hour 8
+      const rushData = makeMultiWeekSnapshots(
+        [15, 15, 15, 15, 15, 15],
+        { hour: 8, dayOfWeek: 3 },
+      );
+      const nonRushData = makeMultiWeekSnapshots(
+        [3, 3, 3, 3, 3, 3],
+        { hour: 14, dayOfWeek: 3 },
+      );
+
+      const mixed = [...rushData, ...nonRushData];
+      const result = computePrediction(mixed, 8, 3); // target is rush hour
+
+      // Unweighted mean = 9. Enhanced weighting gives rush-hour data
+      // a bonus, but trend extrapolation moderates the effect.
+      // The weighted mean (~9.67) is higher than unweighted (9),
+      // confirming the rush-hour bonus is applied.
+      expect(result.predicted).toBeGreaterThanOrEqual(8);
+      expect(result.dataPoints).toBe(12);
+    });
+  });
+
+  // --- Range calculation ---
+
+  describe('range calculation', () => {
+    it('range lower bound is never negative', () => {
+      const snapshots = [0, 1, 0, 1, 0].map((v) => makeSnapshot(v));
+      const result = computePrediction(snapshots, 10, 3);
+      expect(result.range![0]).toBeGreaterThanOrEqual(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Implements **Issue #9** (basic availability prediction) and **Issue #14** (enhanced prediction), bundled since #14 extends #9.

### What's included

**Prediction API** (\pi/src/functions/predict.ts\)
- HTTP trigger: \GET /api/predict?station=3&horizon=30\
- Queries Cosmos DB: last 14 days, same dayOfWeek, same hour (±1h)
- Algorithm: \	rend_extrapolation * 0.6 + historical_mean * 0.4\
- Returns: \{ predicted, confidence, range, dataPoints }\
- Graceful fallback: \{ predicted: null, confidence: 'none', message: 'Insufficient data' }\

**Enhanced algorithm (#14)**
- With 5+ weeks of data: adds day-of-week + hour weighting
- Morning rush (7-9), evening rush (17-19) get higher weight
- Weekend vs weekday differentiation
- Confidence levels: <10 → low, 10-50 → medium, >50 → high

**Frontend integration**
- \src/services/prediction.ts\ — \etchPrediction(stationId, horizonMinutes)\
- \src/hooks/usePrediction.ts\ — \{ prediction, loading, error }\
- \src/components/shared/PredictionBadge.tsx\ — Shows prediction with confidence indicator; grayed out when no data
- Integrated into \StationPopup\ below current availability

**Tests** (\	ests/unit/prediction.test.ts\) — 19 tests
- Algorithm with mock historical data
- No-data graceful fallback
- Confidence level calculation
- Morning/evening rush weighting
- Enhanced day-of-week weighting

> ⚠️ Prediction activates once the Timer Trigger (\stationCollector\) populates Cosmos DB after Azure deployment.

Closes #9, closes #14