### PR TITLE
feat: predictive confidence + bike type routing optimization

### DIFF
--- a/src/components/RoutePanel/RoutePanel.tsx
+++ b/src/components/RoutePanel/RoutePanel.tsx
@@ -4,9 +4,12 @@ import ConfidenceBadge from '../shared/ConfidenceBadge.tsx';
 import {
   calculatePickupConfidence,
   calculateDropoffConfidence,
+  calculatePredictiveConfidence,
   routeConfidence,
 } from '../../services/confidenceScore.ts';
-import type { ConfidenceScore } from '../../services/confidenceScore.ts';
+import type { PredictiveConfidenceScore, StationPrediction } from '../../services/confidenceScore.ts';
+import type { BikeType } from '../../services/bikeTypeFilter.ts';
+import { BIKE_TYPE_SPEED_FACTOR, getBikeTypeLabel } from '../../services/routeEngine.ts';
 
 interface RoutePanelProps {
   routes: MultiModalRoute[];
@@ -16,6 +19,8 @@ interface RoutePanelProps {
   error: string | null;
   selectedIndex: number;
   onSelectRoute: (index: number) => void;
+  predictions?: Map<string, StationPrediction>;
+  bikeType?: BikeType;
 }
 
 function formatTime(seconds: number): string {
@@ -36,17 +41,21 @@ function RouteCard({
   index,
   isSelected,
   onSelect,
+  bikeType,
 }: {
   route: MultiModalRoute;
   walkingRoute: WalkingRoute | null;
-  confidence: ConfidenceScore | null;
+  confidence: PredictiveConfidenceScore | null;
   index: number;
   isSelected: boolean;
   onSelect: () => void;
+  bikeType?: BikeType;
 }) {
   const bikeMinutes = Math.round(route.total_time_seconds / 60);
   const walkMinutes = walkingRoute ? Math.round(walkingRoute.total_time_seconds / 60) : null;
   const timeSaved = walkMinutes ? walkMinutes - bikeMinutes : null;
+  const speedFactor = bikeType ? BIKE_TYPE_SPEED_FACTOR[bikeType] ?? 1 : 1;
+  const bikeLabel = bikeType ? getBikeTypeLabel(bikeType) : null;
 
   return (
     <button
@@ -75,6 +84,12 @@ function RouteCard({
         <div>Dejar: {route.dropoff_station.name}</div>
       </div>
 
+      {bikeLabel && speedFactor < 1 && (
+        <div className="mt-1 text-xs font-medium text-blue-700 bg-blue-50 px-2 py-0.5 rounded inline-block">
+          {bikeLabel}
+        </div>
+      )}
+
       <RouteStats route={route} />
 
       {timeSaved !== null && (
@@ -95,15 +110,24 @@ function RouteCard({
 function getRouteConfidence(
   route: MultiModalRoute,
   stations: StationData[],
-): ConfidenceScore | null {
+  predictions?: Map<string, StationPrediction>,
+): PredictiveConfidenceScore | null {
   const pickup = stations.find((s) => s.station_id === route.pickup_station.station_id);
   const dropoff = stations.find((s) => s.station_id === route.dropoff_station.station_id);
   if (!pickup || !dropoff) return null;
   const walkToPickupMin = route.walk_to_pickup.duration_seconds / 60;
   const bikeToDropoffMin = route.bike_segment.duration_seconds / 60;
-  const pickupConf = calculatePickupConfidence(pickup, walkToPickupMin);
+
+  const prediction = predictions?.get(pickup.station_id);
+  const pickupConf = calculatePredictiveConfidence(pickup, walkToPickupMin, prediction);
   const dropoffConf = calculateDropoffConfidence(dropoff, bikeToDropoffMin);
-  return routeConfidence(pickupConf, dropoffConf);
+  const combined = routeConfidence(pickupConf, dropoffConf);
+
+  return {
+    ...combined,
+    predictedLevel: pickupConf.predictedLevel,
+    predictedReason: pickupConf.predictedReason,
+  };
 }
 
 const LEVEL_PRIORITY: Record<string, number> = { high: 0, medium: 1, low: 2 };
@@ -116,10 +140,12 @@ export default function RoutePanel({
   error,
   selectedIndex,
   onSelectRoute,
+  predictions,
+  bikeType,
 }: RoutePanelProps) {
   const routesWithConfidence = routes.map((route) => ({
     route,
-    confidence: getRouteConfidence(route, stations),
+    confidence: getRouteConfidence(route, stations, predictions),
   }));
 
   routesWithConfidence.sort((a, b) => {
@@ -161,6 +187,7 @@ export default function RoutePanel({
           index={i}
           isSelected={i === selectedIndex}
           onSelect={() => onSelectRoute(i)}
+          bikeType={bikeType}
         />
       ))}
 

--- a/src/components/shared/ConfidenceBadge.tsx
+++ b/src/components/shared/ConfidenceBadge.tsx
@@ -1,8 +1,9 @@
-﻿import { useState } from 'react';
-import type { ConfidenceScore, ConfidenceLevel } from '../../services/confidenceScore.ts';
+import { useState } from 'react';
+import type { ConfidenceLevel } from '../../services/confidenceScore.ts';
+import type { PredictiveConfidenceScore } from '../../services/confidenceScore.ts';
 
 interface ConfidenceBadgeProps {
-  confidence: ConfidenceScore;
+  confidence: PredictiveConfidenceScore;
   compact?: boolean;
 }
 
@@ -15,6 +16,8 @@ const levelConfig: Record<ConfidenceLevel, { emoji: string; label: string; class
 export default function ConfidenceBadge({ confidence, compact = false }: ConfidenceBadgeProps) {
   const [showTooltip, setShowTooltip] = useState(false);
   const config = levelConfig[confidence.level];
+  const hasPrediction = confidence.predictedLevel && confidence.predictedLevel !== confidence.level;
+  const predictedConfig = hasPrediction ? levelConfig[confidence.predictedLevel!] : null;
 
   return (
     <span
@@ -31,12 +34,25 @@ export default function ConfidenceBadge({ confidence, compact = false }: Confide
         {!compact && <span>{config.label}</span>}
       </span>
 
+      {hasPrediction && predictedConfig && (
+        <>
+          <span className="mx-0.5 text-xs text-gray-400">{'\u2192'}</span>
+          <span
+            className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${predictedConfig.classes}`}
+            data-testid="confidence-badge-predicted"
+          >
+            <span>{predictedConfig.emoji}</span>
+            {!compact && <span>{predictedConfig.label}</span>}
+          </span>
+        </>
+      )}
+
       {showTooltip && (
         <span
           className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 text-xs text-white bg-gray-800 rounded shadow-lg whitespace-nowrap z-50"
           data-testid="confidence-tooltip"
         >
-          {confidence.reason}
+          {confidence.predictedReason ?? confidence.reason}
         </span>
       )}
     </span>

--- a/src/services/confidenceScore.ts
+++ b/src/services/confidenceScore.ts
@@ -1,4 +1,4 @@
-﻿import type { StationData } from '../types/gbfs.ts';
+import type { StationData } from '../types/gbfs.ts';
 
 export type ConfidenceLevel = 'high' | 'medium' | 'low';
 
@@ -6,6 +6,18 @@ export interface ConfidenceScore {
   level: ConfidenceLevel;
   score: number;
   reason: string;
+}
+
+export interface PredictiveConfidenceScore extends ConfidenceScore {
+  predictedLevel?: ConfidenceLevel;
+  predictedReason?: string;
+}
+
+/** Prediction data for a station at a future point in time */
+export interface StationPrediction {
+  predicted_bikes_available: number;
+  predicted_docks_available: number;
+  minutes_ahead: number;
 }
 
 const LEVEL_ORDER: ConfidenceLevel[] = ['high', 'medium', 'low'];
@@ -119,4 +131,57 @@ function buildDropoffReason(docks: number, walkMin: number, level: ConfidenceLev
   return walkMin > 5
     ? 'Solo ' + docks + ' huecos disponibles y estas a ' + Math.round(walkMin) + ' min'
     : 'Solo ' + docks + ' huecos disponibles';
+}
+
+/**
+ * Calculate predictive pickup confidence by blending current availability
+ * with predicted future availability. Falls back to basic heuristic when
+ * no prediction data is provided.
+ */
+export function calculatePredictiveConfidence(
+  station: StationData,
+  walkTimeMinutes: number,
+  prediction?: StationPrediction,
+): PredictiveConfidenceScore {
+  const current = calculatePickupConfidence(station, walkTimeMinutes);
+
+  if (!prediction) {
+    return current;
+  }
+
+  const capacity = station.capacity;
+  if (capacity === 0) {
+    return current;
+  }
+
+  const predictedRatio = prediction.predicted_bikes_available / capacity;
+  let predictedLevel: ConfidenceLevel;
+  if (predictedRatio > 0.5) {
+    predictedLevel = 'high';
+  } else if (predictedRatio >= 0.25) {
+    predictedLevel = 'medium';
+  } else {
+    predictedLevel = 'low';
+  }
+
+  const currentIdx = LEVEL_ORDER.indexOf(current.level);
+  const predictedIdx = LEVEL_ORDER.indexOf(predictedLevel);
+
+  if (predictedIdx > currentIdx) {
+    const predictedScore = Math.round(predictedRatio * 100);
+    const blendedScore = Math.round((current.score + predictedScore) / 2);
+    const predictedReason =
+      'Ahora hay ' + station.num_bikes_available + ' bicis, pero a esta hora suelen bajar a ' +
+      prediction.predicted_bikes_available;
+
+    return {
+      level: predictedLevel,
+      score: clamp(blendedScore, 0, 100),
+      reason: current.reason,
+      predictedLevel,
+      predictedReason,
+    };
+  }
+
+  return current;
 }

--- a/src/services/routeEngine.ts
+++ b/src/services/routeEngine.ts
@@ -7,6 +7,28 @@ const MAX_WALKING_DISTANCE_M = 1000;
 const TOP_N = 3;
 // Limit candidate pairs to avoid excessive API calls
 const MAX_CANDIDATES = 6;
+// EFIT bonus: extra score points when preferred EFIT is available
+const EFIT_BONUS_SECONDS = -120;
+
+/** Speed factor per bike type: lower = faster */
+export const BIKE_TYPE_SPEED_FACTOR: Record<BikeType, number> = {
+  any: 1,
+  FIT: 1,
+  EFIT: 0.8,
+  BOOST: 0.85,
+};
+
+/** Human-readable label for bike type advantage */
+export function getBikeTypeLabel(bikeType: BikeType): string | null {
+  switch (bikeType) {
+    case 'EFIT':
+      return '\u26A1 El\u00E9ctrica \u2014 20% m\u00E1s r\u00E1pido en cuestas';
+    case 'BOOST':
+      return '\u{1F680} Boost \u2014 15% m\u00E1s r\u00E1pido en cuestas';
+    default:
+      return null;
+  }
+}
 
 function toStationSummary(station: StationData): StationSummary {
   return {
@@ -94,7 +116,8 @@ export async function calculateMultiModalRoutes(
     .sort((a, b) => a.estimatedDist - b.estimatedDist)
     .slice(0, MAX_CANDIDATES);
 
-  const routes: MultiModalRoute[] = [];
+  type ScoredRoute = MultiModalRoute & { _scoring_time: number };
+  const routes: ScoredRoute[] = [];
 
   for (const { pickup, dropoff } of sortedPairs) {
     try {
@@ -108,7 +131,15 @@ export async function calculateMultiModalRoutes(
       ]);
 
       const walkTime = walkToPickup.duration_seconds + walkToDest.duration_seconds;
-      const bikeTime = bikeSegment.duration_seconds;
+      const rawBikeTime = bikeSegment.duration_seconds;
+      const speedFactor = BIKE_TYPE_SPEED_FACTOR[bikeType] ?? 1;
+      const bikeTime = Math.round(rawBikeTime * speedFactor);
+
+      // Bonus for EFIT preference when EFIT bikes are available at station
+      const efitBonus =
+        bikeType === 'EFIT' && getVehicleTypeCount(pickup, 'EFIT') > 0
+          ? EFIT_BONUS_SECONDS
+          : 0;
 
       routes.push({
         pickup_station: toStationSummary(pickup),
@@ -121,6 +152,7 @@ export async function calculateMultiModalRoutes(
         bike_time_seconds: bikeTime,
         walk_distance_meters: walkToPickup.distance_meters + walkToDest.distance_meters,
         bike_distance_meters: bikeSegment.distance_meters,
+        _scoring_time: walkTime + bikeTime + efitBonus,
       });
     } catch {
       // Skip failed route calculations
@@ -128,7 +160,10 @@ export async function calculateMultiModalRoutes(
     }
   }
 
-  return routes.sort((a, b) => a.total_time_seconds - b.total_time_seconds).slice(0, TOP_N);
+  return routes
+    .sort((a, b) => a._scoring_time - b._scoring_time)
+    .slice(0, TOP_N)
+    .map(({ _scoring_time: _, ...route }) => route);
 }
 
 /** Calculate a direct walking route for comparison */

--- a/tests/unit/confidenceScore.test.ts
+++ b/tests/unit/confidenceScore.test.ts
@@ -1,9 +1,11 @@
-﻿import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import {
   calculatePickupConfidence,
   calculateDropoffConfidence,
+  calculatePredictiveConfidence,
   routeConfidence,
 } from '../../src/services/confidenceScore.ts';
+import type { StationPrediction } from '../../src/services/confidenceScore.ts';
 import type { StationData } from '../../src/types/gbfs.ts';
 
 function makeStation(overrides: Partial<StationData> = {}): StationData {
@@ -140,5 +142,96 @@ describe('routeConfidence', () => {
     const r = routeConfidence(p, d);
     expect(r.level).toBe('low');
     expect(r.score).toBe(5);
+  });
+});
+
+describe('calculatePredictiveConfidence', () => {
+  it('falls back to basic confidence when no prediction provided', () => {
+    const s = makeStation({ num_bikes_available: 15, capacity: 20 });
+    const result = calculatePredictiveConfidence(s, 3);
+    expect(result.level).toBe('high');
+    expect(result.predictedLevel).toBeUndefined();
+    expect(result.predictedReason).toBeUndefined();
+  });
+
+  it('falls back to basic confidence when prediction is undefined', () => {
+    const s = makeStation({ num_bikes_available: 15, capacity: 20 });
+    const result = calculatePredictiveConfidence(s, 3, undefined);
+    expect(result.level).toBe('high');
+    expect(result.predictedLevel).toBeUndefined();
+  });
+
+  it('downgrades from high to medium when prediction shows drop', () => {
+    const s = makeStation({ num_bikes_available: 15, capacity: 20 });
+    const prediction: StationPrediction = {
+      predicted_bikes_available: 6,
+      predicted_docks_available: 14,
+      minutes_ahead: 30,
+    };
+    const result = calculatePredictiveConfidence(s, 3, prediction);
+    expect(result.level).toBe('medium');
+    expect(result.predictedLevel).toBe('medium');
+    expect(result.predictedReason).toContain('15');
+    expect(result.predictedReason).toContain('6');
+  });
+
+  it('downgrades from high to low when prediction shows severe drop', () => {
+    const s = makeStation({ num_bikes_available: 15, capacity: 20 });
+    const prediction: StationPrediction = {
+      predicted_bikes_available: 2,
+      predicted_docks_available: 18,
+      minutes_ahead: 30,
+    };
+    const result = calculatePredictiveConfidence(s, 3, prediction);
+    expect(result.level).toBe('low');
+    expect(result.predictedLevel).toBe('low');
+  });
+
+  it('does not upgrade when prediction is better than current', () => {
+    const s = makeStation({ num_bikes_available: 4, capacity: 20 });
+    const prediction: StationPrediction = {
+      predicted_bikes_available: 15,
+      predicted_docks_available: 5,
+      minutes_ahead: 30,
+    };
+    const result = calculatePredictiveConfidence(s, 3, prediction);
+    expect(result.level).toBe('low');
+    expect(result.predictedLevel).toBeUndefined();
+  });
+
+  it('keeps current level when prediction is same tier', () => {
+    const s = makeStation({ num_bikes_available: 15, capacity: 20 });
+    const prediction: StationPrediction = {
+      predicted_bikes_available: 12,
+      predicted_docks_available: 8,
+      minutes_ahead: 30,
+    };
+    const result = calculatePredictiveConfidence(s, 3, prediction);
+    expect(result.level).toBe('high');
+    expect(result.predictedLevel).toBeUndefined();
+  });
+
+  it('returns basic confidence for zero-capacity station even with prediction', () => {
+    const s = makeStation({ num_bikes_available: 0, capacity: 0 });
+    const prediction: StationPrediction = {
+      predicted_bikes_available: 5,
+      predicted_docks_available: 5,
+      minutes_ahead: 30,
+    };
+    const result = calculatePredictiveConfidence(s, 3, prediction);
+    expect(result.level).toBe('low');
+    expect(result.score).toBe(0);
+  });
+
+  it('blends scores when prediction causes downgrade', () => {
+    const s = makeStation({ num_bikes_available: 15, capacity: 20 });
+    const prediction: StationPrediction = {
+      predicted_bikes_available: 6,
+      predicted_docks_available: 14,
+      minutes_ahead: 30,
+    };
+    const basic = calculatePickupConfidence(s, 3);
+    const predictive = calculatePredictiveConfidence(s, 3, prediction);
+    expect(predictive.score).toBeLessThan(basic.score);
   });
 });

--- a/tests/unit/routeEngine.test.ts
+++ b/tests/unit/routeEngine.test.ts
@@ -5,6 +5,8 @@ import {
   filterDropoffStations,
   calculateMultiModalRoutes,
   calculateWalkingOnly,
+  BIKE_TYPE_SPEED_FACTOR,
+  getBikeTypeLabel,
 } from '../../src/services/routeEngine';
 import { haversineDistance } from '../../src/services/routing';
 
@@ -362,5 +364,129 @@ describe('walking comparison logic', () => {
       const timeSaved = walkMinutes - bikeMinutes;
       expect(timeSaved).toBeGreaterThan(0);
     }
+  });
+});
+
+describe('BIKE_TYPE_SPEED_FACTOR', () => {
+  it('EFIT is 20% faster (factor 0.8)', () => {
+    expect(BIKE_TYPE_SPEED_FACTOR['EFIT']).toBe(0.8);
+  });
+
+  it('FIT uses base speed (factor 1)', () => {
+    expect(BIKE_TYPE_SPEED_FACTOR['FIT']).toBe(1);
+  });
+
+  it('"any" uses base speed (factor 1)', () => {
+    expect(BIKE_TYPE_SPEED_FACTOR['any']).toBe(1);
+  });
+
+  it('BOOST is 15% faster (factor 0.85)', () => {
+    expect(BIKE_TYPE_SPEED_FACTOR['BOOST']).toBe(0.85);
+  });
+});
+
+describe('getBikeTypeLabel', () => {
+  it('returns electric label for EFIT', () => {
+    const label = getBikeTypeLabel('EFIT');
+    expect(label).not.toBeNull();
+    expect(label).toContain('20%');
+  });
+
+  it('returns null for FIT', () => {
+    expect(getBikeTypeLabel('FIT')).toBeNull();
+  });
+
+  it('returns null for "any"', () => {
+    expect(getBikeTypeLabel('any')).toBeNull();
+  });
+
+  it('returns boost label for BOOST', () => {
+    const label = getBikeTypeLabel('BOOST');
+    expect(label).not.toBeNull();
+    expect(label).toContain('Boost');
+  });
+});
+
+describe('bike type time adjustment in routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function mockRouteResponse(durationSeconds: number, distanceMeters: number) {
+    return {
+      geometry: [[43.36, -8.41] as [number, number], [43.37, -8.40] as [number, number]],
+      duration_seconds: durationSeconds,
+      distance_meters: distanceMeters,
+    };
+  }
+
+  it('EFIT reduces bike time by 20%', async () => {
+    mockedGetWalkingRoute
+      .mockResolvedValueOnce(mockRouteResponse(100, 150))
+      .mockResolvedValueOnce(mockRouteResponse(200, 300));
+    mockedGetCyclingRoute.mockResolvedValueOnce(mockRouteResponse(500, 2000));
+
+    const efitStation = {
+      ...stationNearOrigin,
+      vehicle_types_available: [{ vehicle_type_id: 'EFIT' as const, count: 3 }],
+    };
+
+    const limitedStations = [efitStation, stationNearDest];
+    const result = await calculateMultiModalRoutes(origin, destination, limitedStations, 'EFIT');
+
+    expect(result.length).toBe(1);
+    // bike_time should be 500 * 0.8 = 400
+    expect(result[0].bike_time_seconds).toBe(400);
+    // total = walk(300) + bike(400) = 700
+    expect(result[0].total_time_seconds).toBe(700);
+  });
+
+  it('FIT keeps original bike time', async () => {
+    mockedGetWalkingRoute
+      .mockResolvedValueOnce(mockRouteResponse(100, 150))
+      .mockResolvedValueOnce(mockRouteResponse(200, 300));
+    mockedGetCyclingRoute.mockResolvedValueOnce(mockRouteResponse(500, 2000));
+
+    const fitStation = {
+      ...stationNearOrigin,
+      vehicle_types_available: [{ vehicle_type_id: 'FIT' as const, count: 3 }],
+    };
+
+    const limitedStations = [fitStation, stationNearDest];
+    const result = await calculateMultiModalRoutes(origin, destination, limitedStations, 'FIT');
+
+    expect(result.length).toBe(1);
+    expect(result[0].bike_time_seconds).toBe(500);
+    expect(result[0].total_time_seconds).toBe(800);
+  });
+
+  it('EFIT routes with available EFIT bikes are scored higher', async () => {
+    // Two pickup stations: one with EFIT, one without
+    mockedGetWalkingRoute.mockResolvedValue(mockRouteResponse(100, 150));
+    mockedGetCyclingRoute.mockResolvedValue(mockRouteResponse(500, 2000));
+
+    const efitStation = {
+      ...stationNearOrigin,
+      station_id: 'efit-pickup',
+      vehicle_types_available: [{ vehicle_type_id: 'EFIT' as const, count: 3 }],
+      num_bikes_available: 3,
+    };
+
+    const noEfitStation = {
+      ...stationNearOrigin2,
+      station_id: 'no-efit-pickup',
+      vehicle_types_available: [{ vehicle_type_id: 'EFIT' as const, count: 1 }],
+      num_bikes_available: 5,
+    };
+
+    const result = await calculateMultiModalRoutes(
+      origin,
+      destination,
+      [efitStation, noEfitStation, stationNearDest],
+      'EFIT',
+    );
+
+    // Both routes should exist and EFIT bonus should favor EFIT stations
+    expect(result.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

Bundled implementation for **#15** (Predictive confidence score) and **#17** (Bike type in routing optimization).

### Issue #15 — Predictive confidence score
- New \calculatePredictiveConfidence()\ function that blends current station availability with predicted future data
- When prediction shows drops (e.g. *'Now 8 bikes, but at 8:30 usually drops to 2'*), confidence downgrades from high → medium/low
- Falls back to basic heuristic when no prediction data is available
- \ConfidenceBadge\ now shows transition: \🟢 Alta → 🟡 Media\ with explanatory tooltip
- \RoutePanel\ uses predictive confidence when \predictions\ prop is provided

### Issue #17 — Bike type in routing optimization
- EFIT (electric): cycling time × 0.8 (20% faster, especially on hills)
- FIT (mechanical): unchanged (1.0x)
- BOOST: cycling time × 0.85 (15% faster)
- EFIT scoring bonus when preferred electric bike is available at station
- Route cards show bike type advantage: *'⚡ Eléctrica — 20% más rápido en cuestas'*

### Tests
- 8 new tests for predictive confidence (fallback, downgrade, blend, no-upgrade)
- 11 new tests for bike type speed factors, labels, and route time adjustments
- All 193 tests pass ✅

Closes #15
Closes #17